### PR TITLE
stats: add stats page for records

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -202,6 +202,13 @@ RECORDS_UI_ENDPOINTS = dict(
         template='cds_records/record_detail.html',
         record_class='cds.modules.records.api:CDSRecord',
     ),
+    recid_stats=dict(
+        pid_type='recid',
+        route='/record/<pid_value>/stats',
+        template='cds_records/record_stats.html',
+        view_imp='cds.modules.records.views.stats_recid',
+        record_class='cds.modules.records.api:CDSRecord',
+    ),
     recid_preview=dict(
         pid_type='recid',
         route='/record/<pid_value>/preview/<filename>',

--- a/cds/modules/records/bundles.py
+++ b/cds/modules/records/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -17,12 +17,37 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""JS/CSS bundles for DS Records."""
+"""JS/CSS bundles for Records."""
 
 from __future__ import absolute_import, print_function
 
 from flask_assets import Bundle
 from invenio_assets import NpmBundle
+
+stats_js = NpmBundle(
+    'node_modules/d3-tip/index.js',
+    'node_modules/d3-svg-legend/d3-legend.min.js',
+    'node_modules/lodash/lodash.js',
+    'node_modules/invenio-charts-js/dist/lib.bundle.js',
+    'js/cds_records/stats.js',
+    output='gen/cds.records.stats.%(version)s.js',
+    npm={
+        'invenio-charts-js': '^0.1.4',
+        'd3-extended': '^1.2.10',
+        'd3-svg-legend': '^2.24.1',
+        'd3-tip': '^0.7.1',
+        'lodash': '^4.17.4'
+    }
+)
+
+stats_css = Bundle(
+    Bundle(
+        'node_modules/invenio-charts-js/src/styles/styles.scss',
+        'scss/stats.scss',
+        filters='node-scss,cleancssurl',
+    ),
+    output='gen/cds.stats.%(version)s.css',
+)
 
 js = NpmBundle(
     Bundle(

--- a/cds/modules/records/static/js/cds_records/stats.js
+++ b/cds/modules/records/static/js/cds_records/stats.js
@@ -1,0 +1,35 @@
+function getStats(record) {
+  var record_id = record.recid;
+  var defaultConfig = {
+    legend: {
+      visible: false,
+    },
+    tooltip: {
+      enabled: false
+    }
+  };
+  // Fetch the pageviews of the specific record
+  $.ajax({
+    type: 'GET',
+    url: '/api/stats/' + record_id + '/pageviews',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+  .success(function(data) {
+    new inveniographs.LineGraph(data, 'pageviews', defaultConfig).render();
+  });
+
+  // Fetch the downloads of the specific record
+  $.ajax({
+    type: 'GET',
+    url: '/api/stats/' + record_id + '/downloads',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+  .success(function(data) {
+    new inveniographs.LineGraph(data, 'downloads', defaultConfig).render();
+  });
+
+}

--- a/cds/modules/records/static/scss/stats.scss
+++ b/cds/modules/records/static/scss/stats.scss
@@ -1,0 +1,9 @@
+.pageviews, .downloads {
+  height: 30vh;
+  position: relative;
+}
+
+.igj-tip {
+  max-width: 150px;
+  max-height: 70px;
+}

--- a/cds/modules/records/templates/cds_records/record_stats.html
+++ b/cds/modules/records/templates/cds_records/record_stats.html
@@ -1,0 +1,41 @@
+{%- extends 'cds_theme/page.html' %}
+{%- block css %}
+  {{ super() }}
+  {% assets "cds_record_stats_css" %}
+  <link href="{{ ASSET_URL }}" rel="stylesheet">
+  {% endassets %}
+{%- endblock css %}
+
+{%- block javascript %}
+  {{ super() }}
+  {% assets "cds_record_stats_js" %}
+    <script src="{{ ASSET_URL }}"></script>
+    <script>
+      $(document).ready(function() {
+        getStats({{ record | tojson }})
+      });
+    </script>
+  {% endassets %}
+
+{%- endblock javascript %}
+
+{%- block page_header %}
+  {% include "cds_home/header.html" %}
+{%- endblock page_header %}
+
+{%- block page_footer %}
+  {% include "cds_home/footer.html" %}
+{%- endblock page_footer %}
+
+{%- block page_body %}
+<div class='container'>
+  <div class='row'>
+    <div class='col-sm-12'>
+      <h2>Pageviews</h2>
+      <div class='pageviews'></div>
+      <h2>Downloads</h2>
+      <div class='downloads'></div>
+    </div>
+  </div>
+</div>
+{%- endblock page_body %}

--- a/cds/modules/records/views.py
+++ b/cds/modules/records/views.py
@@ -33,6 +33,12 @@ blueprint = Blueprint(
     static_folder='static',
 )
 
+def stats_recid(pid, record, template=None, **kwargs):
+    """Preview file for given record."""
+    return render_template(
+        'cds_records/record_stats.html',
+        record=record
+    )
 
 def records_ui_export(pid, record, template=None, **kwargs):
     """Export a record."""

--- a/setup.py
+++ b/setup.py
@@ -184,6 +184,8 @@ setup(
             'cds_search_ui_js = cds.modules.search_ui.bundles:js',
             'cds_theme_css = cds.modules.theme.bundles:css',
             'cds_theme_js = cds.modules.theme.bundles:js',
+            'cds_record_stats_js = cds.modules.records.bundles:stats_js',
+            'cds_record_stats_css = cds.modules.records.bundles:stats_css',
         ],
         'invenio_base.api_apps': [
             'cds_deposit = cds.modules.deposit.ext:CDSDepositApp',


### PR DESCRIPTION
* Extends 'stats' module to retrieve pageviews, downloads.

* Performs corresponding ES queries (aggregation and filters).

* Extends 'records' module with .scss, .js bundles and a template.

* Adds /record/<record_id>/stats route to demonstrate the graphs.

Signed-off by Ioannis Androulidakis <androulidakis.ioannis@gmail.com>