### PR TITLE
theme: fix search results alignment

### DIFF
--- a/cds/modules/theme/static/templates/cds/video/small.html
+++ b/cds/modules/theme/static/templates/cds/video/small.html
@@ -1,18 +1,21 @@
 <div class="row">
-  <div class="col-md-4 mb-20" ng-repeat="record in vm.invenioSearchResults.hits.hits track by $index">
-    <a class="cds-video-title l-b" target="_self" ng-href="/record/{{ record.id }}">
-      <img
-        class="img-responsive"
-        gif-src="{{ record | iiif:true:[330,190] }}"
-        img-src="{{ record | iiif:false:[330,190] }}"
-        ng-src="{{ record | iiif:false:[330,190] }}"
-        err-src="//unsplash.it/1024/576>?random&blur"
-        image-progressive-loading
-      />
-      <span ng-hide="!record.metadata.duration" class="cds-video-duration">{{ record.metadata.duration }}</span>
-      <p>
-        {{ record.metadata.title.title || 'No title :(' | limitTo: 60}} {{ record.metadata.title.title.length > 60 ? ' [...]' : '' }}
-      </p>
-    </a>
+  <div ng-repeat="record in vm.invenioSearchResults.hits.hits track by $index">
+    <div class="col-md-4 mb-20">
+      <a class="cds-video-title l-b" target="_self" ng-href="/record/{{ record.id }}">
+        <img
+          class="img-responsive"
+          gif-src="{{ record | iiif:true:[330,190] }}"
+          img-src="{{ record | iiif:false:[330,190] }}"
+          ng-src="{{ record | iiif:false:[330,190] }}"
+          err-src="//unsplash.it/1024/576>?random&blur"
+          image-progressive-loading
+        />
+        <span ng-hide="!record.metadata.duration" class="cds-video-duration">{{ record.metadata.duration }}</span>
+        <p>
+          {{ record.metadata.title.title || 'No title :(' | limitTo: 60}} {{ record.metadata.title.title.length > 60 ? ' [...]' : '' }}
+        </p>
+      </a>
+    </div>
+    <div class="clearfix visible-md-block visible-lg-block" ng-if="!(($index+1) % 3)"></div>
   </div>
 </div>


### PR DESCRIPTION
* Fixes the problem when one of the elements in the search results is
  longer than the others in the same row (and it's not the last element
  of the row), then the next row is badly aligned (as described here:
  https://getbootstrap.com/docs/3.3/css/#grid-responsive-resets).