### PR TITLE
deposit: addition of force inherit metadata

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
@@ -125,7 +125,7 @@ function cdsDepositCtrl(
       return Object.getOwnPropertyNames(obj).length == 0;
     };
 
-    this.inheritMetadata = function(specific) {
+    this.inheritMetadata = function(specific, forceInherit) {
       // Inherit metadata from project
       var record = that.record;
       var master = that.cdsDepositsCtrl.master.metadata;
@@ -133,7 +133,7 @@ function cdsDepositCtrl(
       angular.forEach(paths, function(propPath) {
         var inheritedVal = accessElement(master, propPath);
         var ownElement = accessElement(record, propPath);
-        if (inheritedVal && !ownElement) {
+        if ((inheritedVal && !ownElement) || (inheritedVal && forceInherit === true)) {
           accessElement(record, propPath, inheritedVal);
         } else if (ownElement instanceof Array &&
             ownElement.every(hasNoProperties)) {

--- a/cds/modules/deposit/static/templates/cds_deposit/types/video/form.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/video/form.html
@@ -168,9 +168,16 @@
                     <i class="fa fa-cog"></i>
                   </a>
                   <ul class="dropdown-menu">
-                    <li><a ng-click="$ctrl.cdsDepositCtrl.inheritMetadata()">Inherit metadata from the project</a></li>
+                    <li><a ng-click="forceInherit = true">Inherit metadata from the project</a></li>
                     <li><a ng-click="$ctrl.cdsDepositCtrl.inheritMetadata(['contributors'])">Inherit contributors from the project</a></li>
                   </ul>
+                  <modal-dialog show="forceInherit" dialog-title="Inherit metadata from the project" width="50%">
+                    <p class="text-left">Please select if you would like to replace all metadata of this video or inherit only the missing metadata from the project.</p>
+                    <p class="pull-right">
+                      <button class="btn btn-default" ng-click="$ctrl.cdsDepositCtrl.inheritMetadata(undefined, false) ; $parent.hideModal()">Only the missing fields</button>
+                      <button class="btn btn-default" ng-click="$ctrl.cdsDepositCtrl.inheritMetadata(undefined, true) ; $parent.hideModal()">Replace all metadata</button>
+                    </p>
+                  </modal-dialog>
                 </li>
               </ul>
               <!-- Tab panes -->


### PR DESCRIPTION
* Adds force inherit metadata options, a modal is appearing and let
  the user select if they want to inherit only the missing fields or
  replace all the medata. (closes #1034)

Signed-off-by: Harris Tzovanakis <me@drjova.com>