### PR TITLE
deposit: delete old event if reupload master

### DIFF
--- a/requirements.topical.branches.txt
+++ b/requirements.topical.branches.txt
@@ -31,8 +31,8 @@
 # FIXME wait for PR#147
 -e git+https://github.com/inveniosoftware/invenio-files-rest.git@cds-object-version-tags#egg=invenio-files-rest
 
-# FIXME wait for PR#53
--e git+https://github.com/inveniosoftware/invenio-webhooks.git@cds#egg=invenio-webhooks
+# FIXME wait for PR#54
+-e git+https://github.com/hachreak/invenio-webhooks.git@51_receivers_permissions#egg=invenio-webhooks
 
 # FIXME #75
 # -e git+https://github.com/inveniosoftware/invenio-migrator.git#egg=invenio-migrator

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -913,6 +913,8 @@ def templates(app, db):
 @pytest.fixture()
 def local_file(db, bucket, location, online_video):
     """A local file."""
+    # FIXME check where it's used, and substitute with get_local_file
+    # if is involved a video!
     response = requests.get(online_video, stream=True)
     object_version = ObjectVersion.create(
         bucket, "test.mp4", stream=response.raw)

--- a/tests/unit/test_webhook_receivers.py
+++ b/tests/unit/test_webhook_receivers.py
@@ -444,13 +444,14 @@ def test_avc_workflow_receiver_pass(api_app, db, api_project, access_token,
         assert bucket.size == 0
 
         record = RecordMetadata.query.filter_by(id=video_1_id).one()
-        events = get_deposit_events(record.json['_deposit']['id'])
 
         # check metadata patch are deleted
         assert 'extracted_metadata' not in record.json['_cds']
 
         # check the corresponding Event persisted after cleaning
-        assert len(events) == 1
+        assert len(get_deposit_events(record.json['_deposit']['id'])) == 0
+        assert len(get_deposit_events(record.json['_deposit']['id'],
+                                      _deleted=True)) == 1
 
         # check no SSE message and reindexing is fired
         assert mock_sse.called is False
@@ -643,13 +644,14 @@ def test_avc_workflow_receiver_local_file_pass(
         assert bucket.size == 0
 
         record = RecordMetadata.query.filter_by(id=video_1_id).one()
-        events = get_deposit_events(record.json['_deposit']['id'])
 
         # check metadata patch are deleted
         assert 'extracted_metadata' not in record.json['_cds']
 
         # check the corresponding Event persisted after cleaning
-        assert len(events) == 1
+        assert len(get_deposit_events(record.json['_deposit']['id'])) == 0
+        assert len(get_deposit_events(record.json['_deposit']['id'],
+                                      _deleted=True)) == 1
 
         # check no SSE message and reindexing is fired
         assert mock_sse.called is False


### PR DESCRIPTION
* Improves re-upload of master file, marking as deleted the old event
  and create a new one.

* Improves error handling if exception occur on a task.

* Soft-delete files in case of clean to avoid merge conflict. (closes #1112)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>