### PR TITLE
deposit: addition of legacy types

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsForm.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsForm.js
@@ -271,6 +271,18 @@ function cdsFormCtrl($scope, $http, $q, schemaFormDecorators) {
         var categories = that._categories;
         that.types.resolve({ data: [].concat.apply([], categories.map(
           function (category) {
+            // Legacy and Migration ``type`` work around
+            // Check if it has current ``type`` and if it's not part of the types
+            // this means it is a legacy type and we should include it into
+            // the list just for preservation proposes. Please note that
+            // this value will not be visible again if you change the ``type``
+            // and refresh the page.
+            if (that.cdsDepositCtrl.record.type) {
+              var index = category.metadata.types.indexOf(that.cdsDepositCtrl.record.type);
+              if (index === -1) {
+                category.metadata.types.push(that.cdsDepositCtrl.record.type);
+              }
+            }
             return category.metadata.types.map(
               function (type) {
                 return {

--- a/cds/modules/deposit/static/templates/cds_deposit/angular-schema-form/strapselect.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/angular-schema-form/strapselect.html
@@ -9,22 +9,35 @@
        <i ng-if="form.fa_cls" ng-class="'fa fa-fw ' + form.fa_cls"></i>&nbsp;{{ form.title }}
      </label>
     <div class="form-group {{form.fieldHtmlClass}}" ng-init="populateTitleMap(form)">
-        <button ng-if="(form.options.multiple == 'true') || (form.options.multiple == true)"
-                type="button" class="btn btn-default" sf-changed="form" schema-validate="form" ng-model="$$value$$"
-                data-placeholder="{{form.placeholder || form.schema.placeholder || ('placeholders.select')}}"
-                data-html="1" data-multiple="1" data-max-length="{{form.options.inlineMaxLength}}"
-				data-placement="{{form.options.placement || 'bottom-left'}}"
-                data-max-length-html="{{form.options.inlineMaxLengthHtml}}" ng-disabled="form.disabled"
-                bs-options="item.value as item.name for item in form.titleMap | selectFilter:this:$$value$$:&quot;$$value$$&quot;"
-                bs-select>
+        <button
+          ng-if="(form.options.multiple == 'true') || (form.options.multiple == true)"
+          type="button"
+          class="btn btn-default"
+          sf-changed="form"
+          schema-validate="form"
+          ng-model="$$value$$"
+          data-placeholder="{{form.placeholder || form.schema.placeholder || ('placeholders.select')}}"
+          data-html="1"
+          data-multiple="1"
+          data-max-length="{{form.options.inlineMaxLength}}"
+          data-placement="{{form.options.placement || 'bottom-left'}}"
+          data-max-length-html="{{form.options.inlineMaxLengthHtml}}" ng-disabled="form.disabled"
+          bs-options="item.value as item.name for item in form.titleMap | selectFilter:this:$$value$$:&quot;$$value$$&quot;"
+          bs-select>
         </button>
-        <button ng-if="!((form.options.multiple == 'true') || (form.options.multiple == true))"
-                type="button" class="btn btn-default" sf-changed="form" schema-validate="form" ng-model="$$value$$"
-                data-placeholder="{{form.placeholder || form.schema.placeholder || ('placeholders.select')}}"
-                data-html="1" ng-disabled="form.disabled"
-				data-placement="{{form.options.placement || 'bottom-left'}}"
-                bs-options="item.value as item.name for item in form.titleMap | selectFilter:this:$$value$$:&quot;$$value$$&quot;"
-                bs-select>
+        <button
+          ng-if="!((form.options.multiple == 'true') || (form.options.multiple == true))"
+          type="button"
+          class="btn btn-default"
+          sf-changed="form"
+          schema-validate="form"
+          ng-model="$$value$$"
+          data-placeholder="{{form.placeholder || form.schema.placeholder || ('placeholders.select')}}"
+          data-html="1"
+          ng-disabled="form.disabled"
+          data-placement="{{form.options.placement || 'bottom-left'}}"
+          bs-options="item.value as item.name for item in form.titleMap | selectFilter:this:$$value$$:&quot;$$value$$&quot;"
+          bs-select>
         </button>
         <span class="help-block">{{ (hasError() && errorMessage(schemaError())) || form.description}} </span>
     </div>

--- a/cds/modules/deposit/static/templates/cds_deposit/types/project/actions.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/project/actions.html
@@ -17,7 +17,7 @@
 
   <button
     ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status== "draft"'
-    ng-disabled="$ctrl.cdsDepositCtrl.isInvalid() || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
+    ng-disabled="$ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
     class="btn btn-default btn-sm"
     ng-click="$ctrl.actionHandler(['EDIT', 'SAVE_PARTIAL'], '/deposit')">
   Edit Project

--- a/cds/modules/deposit/static/templates/cds_deposit/types/video/actions.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/video/actions.html
@@ -43,7 +43,7 @@ Are you sure you want publish the video?<br>
   </button>
   <button
     ng-hide='$ctrl.cdsDepositCtrl.isDraft()'
-    ng-disabled="$ctrl.cdsDepositCtrl.isInvalid() || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
+    ng-disabled="$ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
     class="btn btn-xs btn-default "
     ng-click="$ctrl.actionHandler(['EDIT', 'SAVE_PARTIAL'], '/deposit')">
   Edit


### PR DESCRIPTION
* Adds the option to display legacy ``type``, when the project is saved
  with a different ``type`` and refresh the page, the type will disappear
  from the list.

* Removes validation check on ``Edit`` buttons, now no matter if the
  deposit is valid or not the user will be able to edit it.

Signed-off-by: Harris Tzovanakis <me@drjova.com>