### PR TITLE
global: fixed symlinks locations by replacing xrootd path

### DIFF
--- a/cds/modules/records/symlinks.py
+++ b/cds/modules/records/symlinks.py
@@ -25,10 +25,14 @@
 """CDS record symlinks."""
 
 import arrow
+import logging
 import os
 
-from flask import current_app
 from invenio_files_rest.models import FileInstance, Location
+
+from cds.modules.xrootd.utils import replace_xrootd
+
+logger = logging.getLogger("cds-symlink-creator")
 
 
 class SymlinksCreator(object):
@@ -57,27 +61,39 @@ class SymlinksCreator(object):
                 yield _file
 
     def _create_symlink_for_file(self, file, record):
+        """Create a new symlink for a given file"""
+
+        logger.info("Creating symlink for a new file")
+
         # fetch file location
         file_instance = FileInstance.get(file['file_id'])
+
         # build the new symlink path
         symlink_path = self._build_link_path(
             self._symlinks_location, record, file['key'])
-        if file_instance and os.path.exists(file_instance.uri):
-            source = file_instance.uri
 
+        source_real_file_path = replace_xrootd(file_instance.uri)
+        logger.debug("Creating symlink for file path: {file_path}"
+                     .format(file_path=source_real_file_path))
+
+        if os.path.exists(source_real_file_path):
             # build symlink path directories recursively
             if not os.path.isdir(os.path.dirname(symlink_path)):
                 os.makedirs(os.path.dirname(symlink_path))
 
-            info = "New symlink - source: {source}\nlink: {link}" \
-                .format(source=source, link=symlink_path)
-            current_app.logger.info(info)
-
             # delete the prev symlink for safety in case it points
             # to another file or it is broken
             self._delete_symlink(symlink_path)
+
+            logger.info("New symlink - source: {source}\nlink: {link}"
+                        .format(source=source_real_file_path,
+                                link=symlink_path))
+
             # create the new symlink
-            os.symlink(source, symlink_path)
+            os.symlink(source_real_file_path, symlink_path)
+        else:
+            logger.error("File path not found: {file_path}"
+                         .format(file_path=source_real_file_path))
 
     def _delete_prev_symlink(self, prev_record, accepted_context_types):
         """Delete the symlink to the previous published file."""
@@ -90,12 +106,18 @@ class SymlinksCreator(object):
     @staticmethod
     def _delete_symlink(link_name):
         """Delete a symlink if it exists."""
-        if os.path.lexists(link_name):
+        real_link_name = replace_xrootd(link_name)
+        path_exists = os.path.lexists(real_link_name)
+
+        logger.debug("Checking old symlink, does {link_name} exist? "
+                     "{exists}".format(link_name=real_link_name,
+                                       exists=path_exists))
+        if path_exists:
             info = "Deleting symlink\nlink: {link}\nWas pointing to: " \
-                "{source}".format(link=link_name,
-                                  source=os.path.realpath(link_name))
-            current_app.logger.info(info)
-            os.unlink(link_name)
+                "{source}".format(link=real_link_name,
+                                  source=os.path.realpath(real_link_name))
+            logger.info(info)
+            os.unlink(real_link_name)
 
     @staticmethod
     def _build_link_path(symlinks_location, record, filename):
@@ -117,5 +139,10 @@ class SymlinksCreator(object):
         # before: /path/to/videos/files
         # after: /path/to/videos/links
         videos_location = Location.get_by_name('videos')
-        base_no_last, _ = os.path.split(videos_location.uri)
-        return os.path.join(base_no_last, links_dir_name)
+        real_videos_location = replace_xrootd(videos_location.uri).rstrip('/')
+
+        base_no_last, _ = os.path.split(real_videos_location)
+        symlinks_location = os.path.join(base_no_last, links_dir_name)
+
+        logger.debug("Symlinks location: {loc}".format(loc=symlinks_location))
+        return symlinks_location


### PR DESCRIPTION
Tested directly in `cdslabs_qa` celery task server, and it is now creating the right symlinks.