### PR TITLE
deposit: fix of licenses

### DIFF
--- a/cds/modules/deposit/static/json/cds_deposit/forms/video.json
+++ b/cds/modules/deposit/static/json/cds_deposit/forms/video.json
@@ -290,7 +290,8 @@
         {
           "key": "license[].material",
           "placeholder": "Material",
-          "title": "Material"
+          "title": "Material",
+          "condition": "arrayIndex !=0"
         },
         {
           "key": "license[].credit",


### PR DESCRIPTION
* Removes `Materials` field from the first license. (closes #1175)

Signed-off-by: Harris Tzovanakis <me@drjova.com>