### PR TITLE
deposit: hide add videos button

### DIFF
--- a/cds/modules/deposit/static/templates/cds_deposit/deposits.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/deposits.html
@@ -97,10 +97,14 @@
                 </a>
               </li>
             </ul>
-            <div class="text-center">
-              <a du-smooth-scroll ng-href="#cds-deposit-main-uploader" class="btn btn-link">
+            <div class="text-center text-muted">
+              <a ng-if="$ctrl.master.metadata._deposit.status !== 'published'" du-smooth-scroll ng-href="#cds-deposit-main-uploader" class="btn btn-link">
                 <i class="fa fa-plus"></i> Add videos
               </a>
+              <p class="text-muted" ng-if="$ctrl.master.metadata._deposit.status == 'published'">
+                <hr />
+                <i class="fa fa-info-circle"></i> Click <strong>Edit Project</strong> to add more videos.
+              </p>
             </div>
           </div>
           <toaster-container toaster-options="{'close-html':'<button>Close</button>',  'showCloseButton':true, 'position-class': 'toast-top-right'}"></toaster-container>


### PR DESCRIPTION
* Hides the ``+ Add videos`` button from the deposit page when the
  project is ``published``, the user should first click the ``Edit``
  button for the button to be visible. (closes #1169)

Signed-off-by: Harris Tzovanakis <me@drjova.com>