### PR TITLE
deposit: inherit translations

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/avc.module.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/avc.module.js
@@ -92,6 +92,7 @@ function cdsDepositsConfig(
     'keywords',
     'license',
     'title.title',
+    'translations',
   ]);
 
   taskRepresentationsProvider.setValues({

--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
@@ -504,11 +504,13 @@ function cdsDepositCtrl(
           type: 'danger',
           errors: response.data.errors || []
         });
+        var message = (String(response.status || '').startsWith('5')) ?
+          'Internal Sever Error' : response.data.message
         // Push a notification
         toaster.pop({
           type: 'error',
           title: that.record.title ? that.record.title.title : 'Video',
-          body: response.data.message,
+          body: message,
           bodyOutputType: 'trustedHtml'
         });
       }


### PR DESCRIPTION
* Adds ``translations`` as part of the inherit functionality.
  (closes #1200)

* Adds ``Internal Server Error`` message on alerts when there is
  a 5XX HTTP status.

Signed-off-by: Harris Tzovanakis <me@drjova.com>