### PR TITLE
migrator: create missing subformats

### DIFF
--- a/cds/modules/migrator/records.py
+++ b/cds/modules/migrator/records.py
@@ -59,7 +59,8 @@ from ..records.tasks import create_symlinks
 from ..records.validators import PartialDraft4Validator
 from ..webhooks.tasks import ExtractFramesTask, ExtractMetadataTask
 from ..xrootd.utils import eos_retry, replace_xrootd
-from .utils import process_fireroles, update_access
+from .utils import process_fireroles, update_access, \
+    cern_movie_to_video_pid_fetcher
 
 logger = logging.getLogger('cds-record-migration')
 
@@ -75,7 +76,8 @@ class CDSRecordDump(RecordDump):
                  dojson_model=marc21):
         """Initialize."""
         pid_fetchers = [
-            report_number_fetcher
+            report_number_fetcher,
+            cern_movie_to_video_pid_fetcher,
         ]
         super(self.__class__, self).__init__(data, source_type, latest_only,
                                              pid_fetchers, dojson_model)

--- a/cds/modules/migrator/records.py
+++ b/cds/modules/migrator/records.py
@@ -32,6 +32,7 @@ import os
 import shutil
 import tempfile
 from copy import deepcopy
+from datetime import datetime, timedelta
 
 import arrow
 from cds_dojson.marc21 import marc21
@@ -677,11 +678,14 @@ class CDSRecordDumpLoader(RecordDumpLoader):
             def _update_record(self, *args, **kwargs):
                 pass
 
+        # execute them at 18h00
+        now = datetime.utcnow()
+        afternoon = now + timedelta(hours=(18 - now.hour))
         for miss in missing:
             TranscodeVideoTaskQuiet().s(
                 version_id=master['version_id'], preset_quality=miss,
                 deposit_id=deposit['_deposit']['id']
-            ).apply_async()
+            ).apply_async(eta=afternoon)
 
 
 class DryRunCDSRecordDumpLoader(CDSRecordDumpLoader):

--- a/cds/modules/migrator/utils.py
+++ b/cds/modules/migrator/utils.py
@@ -25,6 +25,9 @@
 
 from flask import current_app
 
+from invenio_pidstore.fetchers import FetchedPID
+from ..records.providers import CDSReportNumberProvider
+
 
 def process_fireroles(fireroles):
     """Extract firerole definitions."""
@@ -75,3 +78,20 @@ def update_access(data, *access):
             current_rules[k] = list(current_x_rules)
 
     data['_access'] = current_rules
+
+
+def cern_movie_to_video_pid_fetcher(record_uuid, data):
+    """Create a parallel pid for CERN movie and videoclip pid."""
+    splitted = str(data['report_number'][0]).split('-')
+    if len(splitted) > 2 and splitted[1] in ['MOVIE', 'VIDEOCLIP']:
+        splitted[1] = 'VIDEO'
+        report_number = '-'.join(splitted)
+
+        # update report number
+        data['report_number'][0] = report_number
+        # and create a new one with the new value
+        return FetchedPID(
+            provider=CDSReportNumberProvider,
+            pid_type='rn',
+            pid_value=report_number,
+        )

--- a/cds/modules/webhooks/tasks.py
+++ b/cds/modules/webhooks/tasks.py
@@ -48,7 +48,8 @@ from celery.utils.log import get_task_logger
 from flask_iiif.utils import create_gif_from_frames
 from invenio_db import db
 from invenio_files_rest.models import (FileInstance, ObjectVersion,
-                                       ObjectVersionTag, as_object_version)
+                                       ObjectVersionTag, as_object_version,
+                                       as_bucket)
 from invenio_indexer.api import RecordIndexer
 from invenio_pidstore.models import PersistentIdentifier
 from invenio_records import Record
@@ -416,7 +417,7 @@ class ExtractFramesTask(AVCTask):
             raise self.retry(max_retries=5, countdown=5, exc=exc)
 
         # Generate GIF images
-        self._create_gif(bucket=self.object.bucket, frames=frames,
+        self._create_gif(bucket=str(self.object.bucket.id), frames=frames,
                          output_dir=output_folder, master_id=self.obj_id)
 
         # Cleanup
@@ -475,6 +476,7 @@ class ExtractFramesTask(AVCTask):
     def _create_gif(cls, bucket, frames, output_dir, master_id):
         """Generate a gif image."""
         gif_filename = 'frames.gif'
+        bucket = as_bucket(bucket)
 
         images = []
         for f in frames:

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import, print_function
 
 import copy
 import json
+import os
 import random
 import uuid
 from time import sleep
@@ -509,3 +510,26 @@ def get_local_file(bucket, datadir, filename):
     version_id = object_version.version_id
     db.session.commit()
     return version_id
+
+
+def get_frames(*args, **kwargs):
+    """list of frames of a master video."""
+    return [{'key': 'frame-{0}.jpg'.format(index),
+             'tags': {'context_type': 'frame', 'content_type': 'jpg',
+                      'media_type': 'image'},
+             'tags_to_transform': {'timestamp': (index * 10) - 5},
+             'filepath': '/path/to/file'} for index in range(1, 11)]
+
+
+def get_migration_streams(datadir):
+    """Get migration files streams."""
+    def migration_streams(*args, **kwargs):
+        if kwargs['file_']['tags']['media_type'] == 'video':
+            path = join(datadir, 'test.mp4')
+        elif kwargs['file_']['tags']['media_type'] == 'image':
+            if kwargs['file_']['tags']['context_type'] == 'frame':
+                path = join(datadir, kwargs['file_']['key'])
+            else:
+                path = join(datadir, 'frame-1.jpg')
+        return open(path, 'rb'), os.path.getsize(path)
+    return migration_streams

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -55,6 +55,7 @@ from cds.modules.records.api import dump_object, CDSVideosFilesIterator, \
 from cds.modules.webhooks.tasks import ExtractMetadataTask, ExtractFramesTask
 from cds.modules.migrator.cli import \
     sequence_generator as cli_sequence_generator
+from cds.modules.migrator.utils import cern_movie_to_video_pid_fetcher
 
 from helpers import load_json
 
@@ -99,7 +100,8 @@ def test_migrate_pids(app, location, datadir, users):
 
     pids = [pid.pid_value for pid in
             PersistentIdentifier.query.filter_by(object_uuid=record.id)]
-    expected = sorted(['2093596', 'CERN-MOVIE-2012-193'])
+    expected = sorted([
+        '2093596', 'CERN-MOVIE-2012-193', 'CERN-VIDEO-2012-193'])
     assert sorted(pids) == expected
 
 
@@ -309,6 +311,16 @@ def test_migrate_record(frames_required, api_app, location, datadir, es,
                    for form in master['subformat']])
         assert dar == {'16:9'}
 
+    def check_pids(record):
+        """Check pids."""
+        assert record['report_number'][0] == 'CERN-VIDEO-2012-193-001'
+        assert PersistentIdentifier.query.filter_by(
+            pid_value='CERN-VIDEO-2012-193-001').count() == 1
+        assert PersistentIdentifier.query.filter_by(
+            pid_value='CERN-MOVIE-2012-193-001').count() == 1
+
+    db.session.commit()
+
     # check video deposit
     deposit_video_uuid = PersistentIdentifier.query.filter(
         PersistentIdentifier.pid_type == 'depid',
@@ -329,6 +341,7 @@ def test_migrate_record(frames_required, api_app, location, datadir, es,
     check_buckets(video, deposit_video)
     check_first_level_files(video)
     check_first_level_files(deposit_video)
+    check_pids(video)
 
     # try to edit video
     deposit_video = deposit_video_resolver(deposit_video['_deposit']['id'])
@@ -402,3 +415,31 @@ def test_retry_run_extracted_metadata(app):
             side_effect=Exception):
         with pytest.raises(Exception):
             CDSRecordDumpLoader._run_extracted_metadata(master={}, retry=1)
+
+
+def test_multiple_pid_for_movie():
+    """Check multiple pid for movie and videoclip."""
+    # check video
+    data = {'report_number': ['CERN-VIDEO-2017']}
+    assert cern_movie_to_video_pid_fetcher(
+        None, data
+    ) is None
+    assert data['report_number'] == ['CERN-VIDEO-2017']
+    # check videoclip
+    data = {'report_number': ['CERN-VIDEOCLIP-2017']}
+    assert cern_movie_to_video_pid_fetcher(
+        None, data
+    ).pid_value == 'CERN-VIDEO-2017'
+    assert data['report_number'] == ['CERN-VIDEO-2017']
+    # check movie
+    data = {'report_number': ['CERN-MOVIE-2017']}
+    assert cern_movie_to_video_pid_fetcher(
+        None, data
+    ).pid_value == 'CERN-VIDEO-2017'
+    assert data['report_number'] == ['CERN-VIDEO-2017']
+    # check others
+    data = {'report_number': ['CERN-FOOTAGE-2017']}
+    assert cern_movie_to_video_pid_fetcher(
+        None, data
+    ) is None
+    assert data['report_number'] == ['CERN-FOOTAGE-2017']


### PR DESCRIPTION
* Adds missing subformats creation on migration. (closes #1201)
(closes #1199)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>