### PR TITLE
global: fixed drupal export routing

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -290,6 +290,13 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/x-datacite+xml': (
                 'cds.modules.records.serializers.datacite_v31_response'),
         },
+        record_serializers_aliases={
+            'json': 'application/json',
+            'smil': 'application/smil',
+            'vtt': 'text/vtt',
+            'drupal': 'x-application/drupal',
+            'dcite': 'application/x-datacite+xml'
+        },
         search_serializers={
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
@@ -364,6 +371,8 @@ RECORDS_REST_ENDPOINTS = dict(
 )
 
 RECORDS_REST_ENDPOINTS.update(OPENDEFINITION_REST_ENDPOINTS)
+# Query arg name to be able to export records in the specified format
+REST_MIMETYPE_QUERY_ARG_NAME = 'format'
 
 # Sort options records REST API.
 RECORDS_REST_SORT_OPTIONS = dict(

--- a/cds/modules/records/api.py
+++ b/cds/modules/records/api.py
@@ -72,7 +72,7 @@ def _build_file_links(obj):
                     # TODO: JSONSchema host is not the best solution here.
                     scheme=current_app.config['JSONSCHEMAS_URL_SCHEME'],
                     host=current_app.config['JSONSCHEMAS_HOST'],
-                    api=current_app.config['DEPOSIT_FILES_API'].lstrip('/'),
+                    api=current_app.config['DEPOSIT_FILES_API'].strip('/'),
                     bucket=obj.bucket_id,
                     key=obj.key,
                     version_id=obj.version_id,
@@ -101,8 +101,13 @@ class CDSFileObject(FileObject):
 
     @classmethod
     def _link(cls, bucket_id, key, _external=True):
-        return url_for('invenio_files_rest.object_api',
-                       bucket_id=bucket_id, key=key, _external=_external)
+        return u'{scheme}://{host}/{api}/{bucket_id}/{key}'.format(
+                scheme=current_app.config['JSONSCHEMAS_URL_SCHEME'],
+                host=current_app.config['JSONSCHEMAS_HOST'],
+                api=current_app.config['DEPOSIT_FILES_API'].lstrip('/'),
+                bucket_id=bucket_id,
+                key=key,
+            )
 
     def dumps(self):
         """Create a dump of the metadata associated to the record."""

--- a/requirements.pinned.txt
+++ b/requirements.pinned.txt
@@ -83,10 +83,10 @@ invenio-opendefinition==1.0.0a4
 invenio-pidstore==1.0.0b2
 invenio-query-parser==0.6.0
 invenio-records-files==1.0.0a9
-invenio-records-rest==1.0.0b1
+invenio-records-rest==1.0.0b2
 invenio-records-ui==1.0.0b1
 invenio-records[postgresql]==1.0.0b2
-invenio-rest[cors]==1.0.0b1
+invenio-rest[cors]==1.0.0b2
 invenio-search-ui==1.0.0a7
 invenio-search==1.0.0a10
 invenio-sse==1.0.0a2

--- a/setup.py
+++ b/setup.py
@@ -121,10 +121,10 @@ install_requires = [
     'invenio-previewer>=1.0.0a11',
     'invenio-query-parser>=0.6.0',
     'invenio-records-files>=1.0.0a9',
-    'invenio-records-rest>=1.0.0b1',
+    'invenio-records-rest>=1.0.0b2',
     'invenio-records-ui>=1.0.0b1',
     'invenio-records[postgresql]>=1.0.0b2',
-    'invenio-rest[cors]>=1.0.0b1',
+    'invenio-rest[cors]>=1.0.0b2',
     'invenio-search-ui>=1.0.0a7',
     'invenio-search>=1.0.0a10',
     'invenio-sequencegenerator>=1.0.0a2',
@@ -193,6 +193,7 @@ setup(
         'invenio_base.api_blueprints': [
             'cds_records = cds.modules.records.views:blueprint',
             'cds_stats = cds.modules.stats.views:blueprint',
+            'cds_redirector = cds.modules.redirector.views:api_blueprint',
         ],
         'invenio_base.apps': [
             'cds_deposit = cds.modules.deposit.ext:CDSDepositApp',

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -39,6 +39,8 @@ import jsonresolver
 from os.path import dirname, join
 from cds.factory import create_app
 from cds.modules.deposit.api import Project
+from cds.modules.redirector.views import api_blueprint \
+    as cds_api_blueprint
 from cds.modules.webhooks.receivers import CeleryAsyncReceiver
 from cds_sorenson.api import get_preset_id
 from cds_sorenson.error import InvalidResolutionError
@@ -115,6 +117,7 @@ def app():
         THEO_LICENCE_KEY='CHANGE_ME',
     )
     app.register_blueprint(files_rest_blueprint)
+    app.register_blueprint(cds_api_blueprint)
 
     with app.app_context():
         yield app


### PR DESCRIPTION
Still missing tests.

@egabancho for the `def drupal_export_alias():` I am parsing the url we define in the `config.py` with regex, but I am not sure it is worth. Do you prefer to hardcod the url instead?