### PR TITLE
global: css/js fixed for IE support

### DIFF
--- a/cds/modules/deposit/bundles.py
+++ b/cds/modules/deposit/bundles.py
@@ -78,6 +78,7 @@ js_jquery = NpmBundle(
 )
 
 js_deposit_common = Bundle(
+    'js/cds_deposit/main.js',
     'js/cds_deposit/avc/avc.module.js',
     'js/cds_deposit/avc/filters/mergeObjects.js',
     'js/cds_deposit/avc/filters/orderTasks.js',

--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposits.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposits.js
@@ -170,14 +170,15 @@ function cdsDepositsCtrl(
 
   this.filterOutFiles = function(files) {
     // Separate videos from other files
-    var [videos, other] = _.partition(files, function(f) {
-      return that.isVideoFile(f.name);
-    });
+    var partition = _.partition(files, function(f) {
+        return that.isVideoFile(f.name);
+      }),
+      // Index videos by their key
+      videos = _.keyBy(partition[0], function(video) {
+        return that.isVideoFile(video.name);
+      }),
+      other = partition[1];
 
-    // Index videos by their key
-    var videos = _.keyBy(videos, function(video) {
-      return that.isVideoFile(video.name);
-    });
     angular.forEach(videos, function(video) {
       if (!video.key) {
         video.key = video.name;

--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsForm.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsForm.js
@@ -158,14 +158,16 @@ function cdsFormCtrl($scope, $http, $q, schemaFormDecorators) {
   function authorFromUser(query) {
     // Match Lastname, Firstname:Affiliation
     // i.e. Uni, Corn: Pink Clouds
-    var re = /^(\w*,\w*):(\w*)$/
-    var [fullName, affiliation] = query.split(re).splice(1, 2)
-    if (!(fullName && affiliation)) {
+    var re = /^(\w*,\w*):(\w*)$/,
+        nameAffiliation = query.split(re).splice(1, 2);
+
+    if (nameAffiliation.length !== 2) {
       return null;
     }
+
     return formAuthor({
-      name: fullName,
-      affiliations: [affiliation],
+      name: nameAffiliation[0],
+      affiliations: [nameAffiliation[1]],
     });
   }
 

--- a/cds/modules/deposit/static/js/cds_deposit/main.js
+++ b/cds/modules/deposit/static/js/cds_deposit/main.js
@@ -1,0 +1,16 @@
+$(document).ready(function() {
+  // show warning if IE (not supported for deposit)
+  var $cdsDepositIeWarning = $('#cds-deposit-ie-warning');
+  if ($cdsDepositIeWarning.length && isIEBelowEdge()) {
+    $cdsDepositIeWarning.removeClass('hidden');
+  }
+
+  function isIEBelowEdge() {
+    return (
+      navigator.appName == 'Microsoft Internet Explorer' ||
+      !!(navigator.userAgent.match(/Trident/) ||
+      navigator.userAgent.match(/rv:11/)) ||
+      (typeof $.browser !== "undefined" && $.browser.msie == 1)
+    );
+  }
+});

--- a/cds/modules/deposit/templates/cds_deposit/index.html
+++ b/cds/modules/deposit/templates/cds_deposit/index.html
@@ -88,6 +88,9 @@
           </invenio-search-facets>
       </div><!-- ./col-md-3 -->
       <div class="col-md-9">
+          <div id="cds-deposit-ie-warning" class="hidden">
+            <div class="alert alert-danger" role="alert">IE browser below <b>Edge</b> is not supported! Please use the latest version of Safari, Chrome or Firefox.</div>
+          </div>
           <invenio-search-results
             class="list-group"
             template="{{ url_for('static', filename='templates/cds_deposit/search/results.html') }}">

--- a/cds/modules/theme/static/scss/cds.scss
+++ b/cds/modules/theme/static/scss/cds.scss
@@ -111,7 +111,7 @@ i.sort-handle {
 }
 
 .flex-item {
-  flex: 1;
+  flex: 1 0 auto;
 }
 
 .cds-footer-separator {
@@ -277,14 +277,14 @@ i.sort-handle {
 #invenio-search {
   invenio-search {
     display: flex;
-    min-height: 100vh;
+    height: 100vh;
     flex-direction: column;
   }
 }
 #cds-deposit-index {
   invenio-search {
     display: flex;
-    min-height: 100vh;
+    height: 100vh;
     flex-direction: column;
   }
 }
@@ -546,6 +546,11 @@ i.sort-handle {
 
 .ui-select-multiple.ui-select-bootstrap {
   min-height: 34px !important;
+}
+
+#cds-deposit-ie-warning {
+  margin: 50px;
+  text-align: center;
 }
 
 // General

--- a/cds/modules/theme/templates/cds_theme/footer.html
+++ b/cds/modules/theme/templates/cds_theme/footer.html
@@ -23,6 +23,8 @@
         </div>
         <!-- ./Upper -->
       </div>
+    </div>
+    <div class="row">
       <div class="col-md-12">
         <!-- Lower -->
         <div class="cds-footer-lower text-right px-10 pt-5 pb-30">


### PR DESCRIPTION
This should fix the layout issues on cds videos + add a warning on cds deposit.
![screen shot 2017-10-09 at 14 20 12](https://user-images.githubusercontent.com/2089455/31338098-530474d6-acfe-11e7-88c2-2de9fe2765e5.png)

@drjova I had to remove a couple of destructuring assignment because otherwise I cannot have a js function with IE11 to detect the browser version... IE11 does not support it and blocks the js execution :(