### PR TITLE
deposit: fixed wrong list of categories in deposit form

### DIFF
--- a/cds/modules/records/mappings/categories/category-v1.0.0.json
+++ b/cds/modules/records/mappings/categories/category-v1.0.0.json
@@ -9,6 +9,15 @@
         "name": {
           "type": "string"
         },
+        "_access": {
+          "type": "object",
+          "properties": {
+            "read": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        },
         "access": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
* the ES mapping for the field `_access` was missing: the field must
  have `index: not_analyzed` set to get results when using filtered
  queries with terms.
* fixes #1252