### PR TITLE
webhooks: stop task on canceled transcoding job

### DIFF
--- a/cds/modules/webhooks/tasks.py
+++ b/cds/modules/webhooks/tasks.py
@@ -650,8 +650,8 @@ class TranscodeVideoTask(AVCTask):
         while status != 'Finished':
             # Get job status
             status, percentage = get_encoding_status(job_id)
-            if status == 'Error':
-                raise RuntimeError('Error transcoding')
+            if status in ['Error', 'Canceled']:
+                raise RuntimeError('Error transcoding: {0}'.format(status))
             job_info['percentage'] = percentage
 
             # Update task's state for this preset


### PR DESCRIPTION
* Stops the celery task if the transcoding in sorenson was canceled.