### PR TITLE
cds-iiif: open image in 'rb' mode

### DIFF
--- a/cds/modules/cds_iiif/utils.py
+++ b/cds/modules/cds_iiif/utils.py
@@ -37,7 +37,7 @@ def image_opener(uuid):
     bucket, _file = uuid.split(':', 1)
     ret = ObjectVersion.get(bucket, _file).file.uri
     # Open the Image
-    opened_image = file_opener_xrootd(ret)
+    opened_image = file_opener_xrootd(ret, 'rb')
     if '.' in _file:
         ext = _file.split('.')[-1]
         if ext in ['txt', 'pdf']:


### PR DESCRIPTION
* Reads image files in binary mode (otherwise Python3 throws
  exceptions).

In Python 3 you can get this kind of errors: https://github.com/python-pillow/Pillow/issues/1605 if the images are not opened as binaries.