### PR TITLE
deposit: add version to thumbnails URLs

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/avc.module.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/avc.module.js
@@ -105,7 +105,7 @@ function cdsDepositsConfig(
 
   // Initialize url builder
   urlBuilderProvider.setBlueprints({
-    iiif: '/api/iiif/v2/<%=deposit%>:<%=key%>/full/<%=res%>/0/default.png',
+    iiif: '/api/iiif/v2/<%=deposit%>:<%=key%>/full/<%=res%>/0/default.png?version=<%=version%>',
     sse: '/api/deposits/project/<%=id%>/sse',
     categories: '/api/categories',
     video: '/deposit/<%=deposit%>/preview/video/<%=key%>',

--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsUploader.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsUploader.js
@@ -588,11 +588,12 @@ function cdsUploaderCtrl(
     }
   };
 
-  this.thumbnailPreview = function(key) {
+  this.thumbnailPreview = function(frame) {
     return urlBuilder.iiif({
       deposit: that.cdsDepositCtrl.record._buckets.deposit,
-      key: key,
-      res: '150,100'
+      key: frame.key,
+      res: '150,100',
+      version: frame.version_id
     });
   };
 

--- a/cds/modules/deposit/static/templates/cds_deposit/types/common/uploader.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/common/uploader.html
@@ -111,7 +111,7 @@
         <div class="row cds-deposit-thumbnail-pad">
           <div class="cds-deposit-frame-thumbnail" ng-repeat="frame in $ctrl.cdsDepositCtrl.currentMasterFile.frame">
             <a ng-href="{{ frame.links.self }}" target="_blank">
-              <img ng-if="showFrames" width="100%" ng-src="{{ $ctrl.thumbnailPreview(frame.key) }}" />
+              <img ng-if="showFrames" width="100%" ng-src="{{ $ctrl.thumbnailPreview(frame) }}" />
             </a>
           </div>
         </div>

--- a/cds/modules/deposit/static/templates/cds_deposit/types/video/uploader.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/video/uploader.html
@@ -108,12 +108,12 @@
     <div class="cds-deposit-thumbnail-pad">
       <div class="cds-deposit-frame-thumbnail" ng-repeat="frame in $ctrl.cdsDepositCtrl.currentMasterFile.frame">
         <a ng-href="{{ frame.links.self }}" target="_blank">
-          <img width="100%" ng-src="{{ $ctrl.thumbnailPreview(frame.key) }}" />
+          <img width="100%" ng-src="{{ $ctrl.thumbnailPreview(frame) }}" />
         </a>
       </div>
       <div class="cds-deposit-frame-thumbnail" ng-repeat="frame in $ctrl.files | findBy:'context_type':'poster'">
         <a ng-href="{{ frame.links.self }}" target="_blank">
-          <img width="100%" ng-src="{{ $ctrl.thumbnailPreview(frame.key) }}" />
+          <img width="100%" ng-src="{{ $ctrl.thumbnailPreview(frame) }}" />
         </a>
       </div>
     </div>


### PR DESCRIPTION
* Adds version to the URL of each thumbnail. That way, the browser
  won't cache them. Before this fix, thumbnails were automatically
  cached, so after replacing the video with a new one, the new
  thumbnails were not shown. There is no need to handle this version
  parameter in the IIIF, it's used just to prevent browser caching.

Signed-off-by: Sebastian Witowski <witowski.sebastian@gmail.com>