### PR TITLE
deposit: block category/type if video published

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsActions.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsActions.js
@@ -72,6 +72,10 @@ function cdsActionsCtrl($scope, $q, cdsAPI) {
       }
     };
 
+    $scope.$on('cds.deposit.project.saveAll', function() {
+      that.saveAllPartial();
+    });
+
     /*
      * If user is publishing a project, save videos and project first
      */

--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
@@ -124,10 +124,6 @@ function cdsDepositCtrl(
     // Loading
     this.loading = false;
 
-    // save previous values for category and type to detect when the user has changed his selection
-    this.projectPreviousCategory = this.record.category;
-    this.projectPreviousType = this.record.type;
-
     this.findFilesByContextType = function(type) {
       return _.find(that.record._files, {'context_type': type});
     }

--- a/cds/modules/deposit/static/json/cds_deposit/forms/project.json
+++ b/cds/modules/deposit/static/json/cds_deposit/forms/project.json
@@ -61,7 +61,8 @@
         "title": "Category",
         "type": "strapselect",
         "htmlClass": "cds-deposit-strap-select",
-        "onChange": "$ctrl.updateCategoryAndPermissions(modelValue, form)",
+        "onChange": "$ctrl.updateCategory(modelValue, form)",
+        "readonly": "$ctrl.isAnyVideoAlreadyPublished()",
         "options": {
           "url": "/api/categories/",
           "asyncCallback": "$ctrl.autocompleteCategories"
@@ -73,8 +74,8 @@
         "title": "Type",
         "type": "strapselect",
         "htmlClass": "cds-deposit-strap-select",
-        "onChange": "$ctrl.updateTypeAndPermissions(modelValue, form)",
-        "readonly": "$ctrl.cdsDepositCtrl.hasCategory() || $ctrl.cdsDepositCtrl.isPublished()",
+        "onChange": "$ctrl.updateType(modelValue, form)",
+        "readonly": "$ctrl.cdsDepositCtrl.hasCategory() || $ctrl.isAnyVideoAlreadyPublished()",
         "options": {
           "filterTriggers": ["model.category"],
           "filter" : "item.category == model.category",
@@ -197,7 +198,8 @@
         "title": "Category",
         "type": "strapselect",
         "htmlClass": "cds-deposit-strap-select",
-        "onChange": "$ctrl.updateCategoryAndPermissions(modelValue, form)",
+        "onChange": "$ctrl.updateCategory(modelValue, form)",
+        "readonly": "$ctrl.isAnyVideoAlreadyPublished()",
         "options": {
           "url": "/api/categories/",
           "asyncCallback": "$ctrl.autocompleteCategories"
@@ -212,8 +214,8 @@
         "title": "Type",
         "type": "strapselect",
         "htmlClass": "cds-deposit-strap-select",
-        "onChange": "$ctrl.updateTypeAndPermissions(modelValue, form)",
-        "readonly": "$ctrl.cdsDepositCtrl.hasCategory() || $ctrl.cdsDepositCtrl.isPublished()",
+        "onChange": "$ctrl.updateType(modelValue, form)",
+        "readonly": "$ctrl.cdsDepositCtrl.hasCategory() || $ctrl.isAnyVideoAlreadyPublished()",
         "options": {
           "filterTriggers": ["model.category"],
           "filter" : "item.category == model.category",

--- a/cds/modules/deposit/static/templates/cds_deposit/types/project/form.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/project/form.html
@@ -26,25 +26,6 @@
         </div>
       </div>
       <!-- /Alerts -->
-      <!-- Modal: change category/type warning -->
-      <modal-dialog show="$ctrl.showCategoryTypeChangeDialog" dialog-title="Are you sure you want to change the category/type?" width="50%">
-        <p class="text-left">
-          You are about to change the category or the type of videos.<br />
-          The following videos are already <strong>published</strong>:
-          <ul>
-              <li ng-repeat="title in $ctrl.alreadyPublishedVideosTitles">
-                  {{ title }}
-              </li>
-          </ul>
-          If you confirm this change, videos will be changed to "draft" status first, their category
-          and type will be updated to your new selection and you will need to republish the videos to apply the change.
-        </p>
-        <p class="pull-right">
-          <button class="btn btn-default" ng-click="$parent.hideModal(); $ctrl.rollbackCategoryTypeChange()">Cancel</button>
-          <button class="btn btn-success" ng-click="$parent.hideModal(); $ctrl.updateCategoryTypeAndPermissions()">Confirm</button>
-        </p>
-      </modal-dialog>
-      <!-- /Modal -->
       <!-- Collapsed -->
       <div ng-init="projectCollapsed=true" ng-show="projectCollapsed">
         <div ng-show="$ctrl.cdsDepositCtrl.isPublished()">
@@ -86,8 +67,9 @@
             </div>
           </div>
           <div class="row">
-              <div class="col-sm-12 text-center">
-                <span class="text-muted">Select category and type, they will be applied to the project and all videos.</span>
+              <div class="col-sm-12 text-center text-muted">
+                <span ng-if="!$ctrl.isAnyVideoAlreadyPublished()">Select category and type, they will be applied to the project and all videos.</span>
+                <span ng-if="$ctrl.isAnyVideoAlreadyPublished()">Category and type can be changed only if no video has been published yet.</span>
               </div>
           </div>
         </div>


### PR DESCRIPTION
- category and type fields are disabled if at least one video was
previously published.
- project and videos are saved on category/type change and forms are
reset to pristine.
- closes #1294
- closes #1297