### PR TITLE
ffmpeg: set ffprobe verbosity to quiet

### DIFF
--- a/cds/modules/ffmpeg/ffmpeg.py
+++ b/cds/modules/ffmpeg/ffmpeg.py
@@ -65,11 +65,16 @@ def ff_probe_all(input_filename):
     * *-show_format -print_format json* output in JSON format
     * *-show_streams -select_streams v:0* show information for video streams
     """
+    cmd = 'ffprobe -v quiet -show_format -print_format json -show_streams ' \
+          '-select_streams v:0 {0}'.format(input_filename)
     metadata = run_command(
-        'ffprobe -v error -show_format -print_format json -show_streams '
-        '-select_streams v:0 {0}'.format(input_filename),
-        error_class=MetadataExtractionExecutionError
+        cmd, error_class=MetadataExtractionExecutionError
     ).decode('utf-8')
+
+    if not metadata:
+        raise MetadataExtractionExecutionError(
+            'No metadata extracted running {0}, '
+            'try to increase verbosity to see the errors')
 
     return _refactoring_metadata(_patch_aspect_ratio(json.loads(metadata)))
 

--- a/tests/unit/test_webhook_tasks.py
+++ b/tests/unit/test_webhook_tasks.py
@@ -288,7 +288,7 @@ def test_task_failure(celery_not_fail_on_eager_app, db, cds_depid, bucket):
 
     message = listener.await()
     assert '"state": "FAILURE"' in message
-    assert 'invalid_uri: No such file or directory' in message
+    assert 'MetadataExtractionExecutionError' in message
 
 
 def test_transcode_too_high_resolutions(db, bucket):


### PR DESCRIPTION
* When minor errors occur while running ffprobe `-v error` prints them embedded on the JSON output, making loading the result fail. Decreasing the level to `quiet` and checking the output seems a better solution.