### PR TITLE
ui: fixed encoding issues

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -267,7 +267,7 @@ OAISERVER_RECORD_INDEX = 'records'
 RECORDS_UI_TOMBSTONE_TEMPLATE = 'invenio_records_ui/tombstone.html'
 
 CDS_RECORDS_RELATED_QUERY = \
-    '/api/records/?size=3&sort=mostrecent&q={0}'
+    '/api/records/?size=3&sort=mostrecent&q=%s'
 
 # Endpoints for record API.
 _Record_PID = 'pid(recid, record_class="cds.modules.records.api:CDSRecord")'

--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsForm.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsForm.js
@@ -90,6 +90,7 @@ function cdsFormCtrl($scope, $http, $q, schemaFormDecorators) {
   function autocomplete(paramsProvider, responseHandler) {
     return function(options, query) {
       if (query) {
+        query = encodeURIComponent(query);
         return $http.get(options.url, {
           params: paramsProvider(query, options)
         }).then(function(data) {

--- a/cds/modules/records/templates/cds_records/record_detail.html
+++ b/cds/modules/records/templates/cds_records/record_detail.html
@@ -38,15 +38,15 @@
 {%- endblock page_footer %}
 
 {%- block page_body %}
-  {% set refer_query = "and -recid:{0}".format(record['recid']) %}
+  {% set refer_query = "and -recid:%s" % record['recid'] %}
   {% if record['keywords'] %}
     {% set keywords = [] %}
     {% for keyword in record['keywords'] %}
       {% set keywords = keywords.append(keyword['name']) %}
     {% endfor %}
-    {% set refer_query = "keywords.name:{0} {1}".format(",".join(keywords), refer_query) %}
+    {% set refer_query = "keywords.name:%s %s" % (",".join(keywords), refer_query) %}
   {% else %}
-    {% set refer_query = "category:{0} {1}".format(record['category'], refer_query) %}
+    {% set refer_query = "category:%s %s" % (record['category'], refer_query) %}
   {% endif %}
   <div id="cds-record">
     {% if config.LOG_USER_ACTIONS_ENABLED %}
@@ -77,7 +77,7 @@
       <!-- List group -->
       <invenio-search
         disable-url-handler="true"
-        search-endpoint='{{ config.CDS_RECORDS_RELATED_QUERY.format(refer_query) }}'
+        search-endpoint='{{ config.CDS_RECORDS_RELATED_QUERY % refer_query }}'
       >
         <div class="text-center">
           <invenio-search-loading


### PR DESCRIPTION
- fixed UnicodeEncodeError on record details view when keywords contains
non ASCII chars.
- fixed deposit ui which fails when searching for keywords with non
ASCII chars.
- removed all dangerous .format() from Jinja2 templates because it
breaks when formatting unicode strings
- See: https://github.com/pallets/jinja/issues/392
- addresses #1332