### PR TITLE
iiif: thumbnails cache busting

### DIFF
--- a/cds/modules/cds_iiif/utils.py
+++ b/cds/modules/cds_iiif/utils.py
@@ -34,7 +34,10 @@ def image_opener(uuid):
     :returns: a file path or handle to the file or its preview image
     :rtype: string or handle
     """
-    bucket, _file = uuid.split(':', 1)
+    # Drop the "version" that comes after the second ":" - we use this version
+    # only as key in redis cache
+    bucket, _file = uuid.split(':')[:2]
+
     ret = ObjectVersion.get(bucket, _file).file.uri
     # Open the Image
     opened_image = file_opener_xrootd(ret, 'rb')

--- a/cds/modules/deposit/static/js/cds_deposit/avc/avc.module.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/avc.module.js
@@ -105,7 +105,7 @@ function cdsDepositsConfig(
 
   // Initialize url builder
   urlBuilderProvider.setBlueprints({
-    iiif: '/api/iiif/v2/<%=deposit%>:<%=key%>/full/<%=res%>/0/default.png?version=<%=version%>',
+    iiif: '/api/iiif/v2/<%=deposit%>:<%=key%>:<%=version%>/full/<%=res%>/0/default.png',
     sse: '/api/deposits/project/<%=id%>/sse',
     categories: '/api/categories',
     video: '/deposit/<%=deposit%>/preview/video/<%=key%>',


### PR DESCRIPTION
* Fixes the problem that thumbnails for frames were not updated if the
  video was replaced - it was caused by the fact, that the key used in
  redis for caching was using the filename, and the file name doesn't
  change if we replace the video in the deposit (but the version of the
  file changes, so we are adding it to the cache key).

Signed-off-by: Sebastian Witowski <witowski.sebastian@gmail.com>