### PR TITLE
deposit: preview the replaced file

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsUploader.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsUploader.js
@@ -365,6 +365,7 @@ function cdsUploaderCtrl(
             var old_event_id = old_master[0]['tags']['_event_id']
             that.deleteEvent(old_event_id).then(
               function success(response) {
+                that.cdsDepositCtrl.previewer = null;
                 that.upload();
               },
               function error(response) {


### PR DESCRIPTION
* Fixes the previewer to preview the new file, after it has been
  replaced.

Signed-off-by: Sebastian Witowski <witowski.sebastian@gmail.com>