### PR TITLE
requirements: remove invenio-files-rest

### DIFF
--- a/requirements.pinned.txt
+++ b/requirements.pinned.txt
@@ -78,7 +78,6 @@ invenio-celery==1.0.0b3
 invenio-communities==1.0.0a16
 invenio-config==1.0.0b3
 invenio-db[postgresql,versioning]==1.0.0b8
-invenio-files-rest==1.0.0a21  # via invenio-communities, invenio-records-files
 invenio-formatter[badges]==1.0.0b3
 invenio-i18n==1.0.0b4     # via invenio-accounts, invenio-theme
 invenio-indexer==1.0.0a10


### PR DESCRIPTION
* Removes invenio-files-rest from pinned dependencies as it is already
  in the requirements.topical.branches.