### PR TITLE
templates: fix keywords links

### DIFF
--- a/cds/modules/records/static/templates/cds_records/keywords.html
+++ b/cds/modules/records/static/templates/cds_records/keywords.html
@@ -3,7 +3,7 @@
   <div class="cds-tags">
     <ul>
       <li ng-repeat="keyword in record.metadata.keywords">
-        <a ng-href='/search?keyword={{ keyword.name }}'>{{ keyword.name }}</a>
+        <a ng-href='/search?q=keywords.name:"{{ keyword.name }}"'>{{ keyword.name }}</a>
       </li>
     </ul>
   </div>

--- a/cds/modules/records/templates/cds_records/record_detail.html
+++ b/cds/modules/records/templates/cds_records/record_detail.html
@@ -45,7 +45,7 @@
     {% for keyword in record['keywords'] %}
       {% set keywords = keywords.append(keyword['name']) %}
     {% endfor %}
-    {% set refer_query = "keywords.name:%s %s" % (",".join(keywords), refer_query) %}
+    {% set refer_query = 'keywords.name:"%s" %s' % ('" or keywords.name:"'.join(keywords), refer_query) %}
   {% else %}
     {% set refer_query = "category:%s %s" % (record['category'], refer_query) %}
   {% endif %}


### PR DESCRIPTION
* Fixed the links of the keywords on the record_detail page, so their
  URLS have a correct search query (closes #1435).

Signed-off-by: Sebastian Witowski <witowski.sebastian@gmail.com>