### PR TITLE
redirector: fix redirect on project report number

### DIFF
--- a/cds/modules/redirector/views.py
+++ b/cds/modules/redirector/views.py
@@ -33,6 +33,8 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from invenio_pidstore.models import PersistentIdentifier
 
+from cds.modules.records.api import Record
+
 blueprint = Blueprint(
     'cds_redirector',
     __name__,
@@ -47,16 +49,17 @@ api_blueprint = Blueprint(
 
 
 def recid_from_rn(report_number):
-    """Retrieves a report number's corresponding record ID."""
+    """Retrieve a report number's corresponding record ID."""
     object_uuid = PersistentIdentifier.query.filter_by(
         pid_type='rn',
         pid_value=report_number
     ).one().object_uuid
-    return PersistentIdentifier.query.filter_by(
-        pid_type='recid',
-        object_type='rec',
-        object_uuid=object_uuid
-    ).one().pid_value
+
+    record = Record.get_record(object_uuid).replace_refs()
+    videos = record.get('videos')
+    if videos:
+        return videos[0]['recid']
+    return record.get('recid')
 
 
 # /record/<pid_value>/embed/<filename>
@@ -95,5 +98,3 @@ def drupal_export_alias():
         format_param)
 
     return redirect(api_url, code=301)
-
-


### PR DESCRIPTION
* Old embeded videos pointing to project's report number, that causing
  404 in the new system. With this fix if the report number belongs to
  a project, it will automatically redirect to the first video.

Signed-off-by: Harris Tzovanakis <me@drjova.com>
Co-authored-by: Esteban J. G. Gabancho <esteban.gabancho@gmail.com>