### PR TITLE
maintenance: new module for recurrent admin tasks

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -40,7 +40,6 @@ from invenio_opendefinition.config import OPENDEFINITION_REST_ENDPOINTS
 from invenio_records_rest.facets import range_filter, terms_filter
 
 from .modules.deposit.facets import created_by_me_aggs
-from .modules.migrator.cli import dumps  # noqa
 from .modules.records.permissions import (deposit_delete_permission_factory,
                                           deposit_read_permission_factory,
                                           deposit_update_permission_factory,
@@ -56,7 +55,7 @@ def _(x):
     return x
 
 
-# CDS Enviroments
+# CDS Environments
 CDS_ENV_PROD = False
 CDS_ENV_TEST = False
 

--- a/cds/modules/deposit/api.py
+++ b/cds/modules/deposit/api.py
@@ -246,8 +246,7 @@ class CDSDeposit(Deposit):
     def dumps(self, **kwargs):
         """Return pure Python dictionary with record metadata."""
         self._update_tasks_status()
-        data = super(CDSDeposit, self).dumps(**kwargs)
-        return data
+        return super(CDSDeposit, self).dumps(**kwargs)
 
     def _update_tasks_status(self):
         """Update tasks status."""
@@ -910,6 +909,7 @@ class Video(CDSDeposit):
         for event in events:
             event.receiver.delete(event=event)
 
+    @mark_as_action
     def delete(self, force=True, pid=None):
         """Delete a video."""
         ref_old = self.ref

--- a/cds/modules/fixtures/data/pages/faq.html
+++ b/cds/modules/fixtures/data/pages/faq.html
@@ -5,7 +5,7 @@
 <p>Click on the &quot;upload&quot; link close to your account name (you might have to log in).
 Click on the &quot;New Upload&quot; button.
 Upload your video file either selecting it or by URL.
-In the screen that appears, you can check the advancement of the upload of the video and the extraction of other files and formats (lower resolution/slave versions, thumbnail pictures, etc.) and you can also enter metadata about the video.
+In the screen that appears, you can check the upload progress of the video and the extraction of other files and formats (other video formats, thumbnail pictures, etc.) and you can also enter metadata about the video.
 Automatically a &quot;Project&quot; is created: the Project will allow you to group several (master) videos together, if needed, and to group other files associated to the video (e.g. pdf or slides of the presentation, etc.).
 Note that you have to select the Category and Type of video, which will set the access rights and visibility.
 Note that the video and the associated data and files are not be available publicly yet, the upload being in Draft state untill you set it to Published state.

--- a/cds/modules/fixtures/data/videos/ATLAS-VIDEO-2017-013.json
+++ b/cds/modules/fixtures/data/videos/ATLAS-VIDEO-2017-013.json
@@ -272,7 +272,7 @@
             }
           },
           {
-            "key": "slave_240p.mp4",
+            "key": "240p.mp4",
             "tags": {
               "context_type": "subformat",
               "media_type": "video",
@@ -287,7 +287,7 @@
             }
           },
           {
-            "key": "slave_360p.mp4",
+            "key": "360p.mp4",
             "tags": {
               "context_type": "subformat",
               "media_type": "video",
@@ -301,7 +301,7 @@
             }
           },
           {
-            "key": "slave_480p.mp4",
+            "key": "480p.mp4",
             "tags": {
               "context_type": "subformat",
               "media_type": "video",
@@ -315,7 +315,7 @@
             }
           },
           {
-            "key": "slave_720p.mp4",
+            "key": "720p.mp4",
             "tags": {
               "context_type": "subformat",
               "media_type": "video",
@@ -329,7 +329,7 @@
             }
           },
           {
-            "key": "slave_1080p.mp4",
+            "key": "1080p.mp4",
             "tags": {
               "context_type": "subformat",
               "media_type": "video",

--- a/cds/modules/maintenance/__init__.py
+++ b/cds/modules/maintenance/__init__.py
@@ -21,10 +21,5 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-"""Migrator Module."""
 
-import warnings
-
-warnings.warn(
-    "The migrator module is now deprecated. Use it at your own risk!",
-    DeprecationWarning)
+"""CDS Videos maintenance module"""

--- a/cds/modules/maintenance/cli.py
+++ b/cds/modules/maintenance/cli.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""CDS Fixture Modules."""
+
+from __future__ import absolute_import, print_function
+
+import click
+from cds_sorenson.api import get_all_distinct_qualities
+from click import ClickException
+from flask.cli import with_appcontext
+
+from cds.modules.maintenance.subformats import create_all_missing_subformats, \
+    create_all_subformats, create_subformat
+
+
+def abort_if_false(ctx, param, value):
+    if not value:
+        ctx.abort()
+
+
+@click.group()
+def subformats():
+    """Slaves command line utilities."""
+
+
+@subformats.command()
+@click.option('--recid', 'recid', default=None)
+@click.option('--depid', 'depid', default=None)
+@with_appcontext
+def missing(recid, depid):
+    """Create missing subformats given a record id or deposit id."""
+    if not recid and not depid:
+        raise ClickException('Missing option "--recid" or "--depid"')
+
+    value = recid or depid
+    type = 'recid' if recid else 'depid'
+    output = create_all_missing_subformats(id_type=type, id_value=value)
+    if output:
+        click.echo("Creating the following subformats: {0}".format(output))
+    else:
+        click.echo("No missing format to create")
+
+
+@subformats.group()
+def recreate():
+    """Recreate subformats for a video."""
+
+
+@recreate.command()
+@click.argument('quality')
+@click.option('--recid', 'recid', default=None)
+@click.option('--depid', 'depid', default=None)
+@with_appcontext
+def quality(recid, depid, quality):
+    """Recreate subformat for the given quality."""
+    if not recid and not depid:
+        raise ClickException('Missing option "--recid" or "--depid"')
+
+    value = recid or depid
+    type = 'recid' if recid else 'depid'
+
+    qualities = get_all_distinct_qualities()
+    if quality not in qualities:
+        raise ClickException(
+            "Input quality must be one of {0}".format(qualities))
+
+    output = create_subformat(id_type=type, id_value=value, quality=quality)
+    if output:
+        click.echo("Creating the following subformat: {0}".format(output))
+    else:
+        click.echo("This subformat cannot be transcoded.")
+
+
+@recreate.command()
+@click.option('--recid', 'recid', default=None)
+@click.option('--depid', 'depid', default=None)
+@click.option('--yes', is_flag=True, callback=abort_if_false,
+              expose_value=False,
+              prompt='Do you really want to recreate all subformats?')
+@with_appcontext
+def all(recid, depid):
+    """Recreate all subformats."""
+    if not recid and not depid:
+        raise ClickException('Missing option "--recid" or "--depid"')
+
+    value = recid or depid
+    type = 'recid' if recid else 'depid'
+
+    output = create_all_subformats(id_type=type, id_value=value)
+    click.echo("Creating the following subformats: {0}".format(output))

--- a/cds/modules/maintenance/subformats.py
+++ b/cds/modules/maintenance/subformats.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""A module for common maintenance scripts."""
+
+from __future__ import absolute_import, print_function
+
+from celery import chain
+
+from .tasks import MaintenanceTranscodeVideoTask
+from cds_sorenson.api import get_all_distinct_qualities, can_be_transcoded
+
+from cds.modules.deposit.api import deposit_video_resolver
+from cds.modules.records.api import CDSVideosFilesIterator
+from cds.modules.records.resolver import record_resolver
+
+id_types = ['recid', 'depid']
+
+
+def create_all_missing_subformats(id_type, id_value):
+    """Create all missing subformats."""
+    _validate(id_type=id_type)
+
+    video_deposit, dep_uuid = _resolve_deposit(id_type, id_value)
+    master, ar, w, h = _get_master_video(video_deposit)
+    subformats = CDSVideosFilesIterator.get_video_subformats(master)
+
+    dones = [subformat['tags']['preset_quality'] for subformat in subformats]
+    missing = set(get_all_distinct_qualities()) - set(dones)
+    transcodables = list(
+        filter(lambda q: can_be_transcoded(q, ar, w, h), missing))
+
+    # sequential (and immutable) transcoding to avoid MergeConflicts on bucket
+    if transcodables:
+        chain([
+            MaintenanceTranscodeVideoTask().si(
+                version_id=master['version_id'],
+                preset_quality=quality,
+                deposit_id=dep_uuid
+            ) for quality in transcodables]).apply_async()
+
+    return transcodables
+
+
+def create_subformat(id_type, id_value, quality):
+    """Recreate a given subformat."""
+    _validate(id_type=id_type, quality=quality)
+
+    video_deposit, dep_uuid = _resolve_deposit(id_type, id_value)
+    master, ar, w, h = _get_master_video(video_deposit)
+
+    subformat = can_be_transcoded(quality, ar, w, h)
+    if subformat:
+        MaintenanceTranscodeVideoTask().s(
+            version_id=master['version_id'],
+            preset_quality=subformat['quality'],
+            deposit_id=dep_uuid
+        ).apply_async()
+
+        return subformat
+
+
+def create_all_subformats(id_type, id_value):
+    """Recreate all subformats."""
+    _validate(id_type=id_type)
+
+    video_deposit, dep_uuid = _resolve_deposit(id_type, id_value)
+    master, ar, w, h = _get_master_video(video_deposit)
+
+    transcodables = list(filter(lambda q: can_be_transcoded(q, ar, w, h),
+                                get_all_distinct_qualities()))
+
+    # sequential (and immutable) transcoding to avoid MergeConflicts on bucket
+    if transcodables:
+        chain([
+            MaintenanceTranscodeVideoTask().si(
+                version_id=master['version_id'],
+                preset_quality=quality,
+                deposit_id=dep_uuid
+            )
+            for quality in transcodables]).apply_async()
+
+    return transcodables
+
+
+def _resolve_deposit(id_type, id_value):
+    """Return the deposit video."""
+    dep_uuid = id_value
+    if id_type == 'recid':
+        _, record = record_resolver.resolve(id_value)
+        dep_uuid = record['_deposit']['id']
+
+    return deposit_video_resolver(dep_uuid), dep_uuid
+
+
+def _get_master_video(video_deposit):
+    """Return master video."""
+    master = CDSVideosFilesIterator.get_master_video_file(video_deposit)
+    if not master:
+        raise Exception("No master video found for the given record")
+
+    return master, master['tags']['display_aspect_ratio'], \
+           int(master['tags']['width']), int(master['tags']['height'])
+
+
+def _validate(id_type=None, quality=None):
+    """Validate input parameters."""
+    if id_type not in id_types:
+        raise Exception('`id_type` param must be one of {0}'.format(id_types))
+
+    all_possible_qualities = get_all_distinct_qualities()
+    if quality and quality not in all_possible_qualities:
+        raise Exception('`quality` param must be one of {0}'.format(
+            all_possible_qualities))

--- a/cds/modules/maintenance/tasks.py
+++ b/cds/modules/maintenance/tasks.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Tasks for maintenance scripts."""
+
+from celery.utils.log import get_task_logger
+
+from invenio_db import db
+
+from cds.modules.deposit.api import deposit_video_resolver
+from cds.modules.records.resolver import record_resolver
+from cds.modules.webhooks.tasks import TranscodeVideoTask
+
+logger = get_task_logger(__name__)
+
+
+class MaintenanceTranscodeVideoTask(TranscodeVideoTask):
+    """Transcode without indexing or sending sse messages."""
+
+    def run(self, preset_quality, sleep_time=5, *args, **kwargs):
+        super(MaintenanceTranscodeVideoTask, self).run(
+            preset_quality=preset_quality,
+            sleep_time=sleep_time,
+            *args,
+            **kwargs)
+
+        logger.debug("Updating deposit and record")
+        # get deposit and record
+        dep_video = deposit_video_resolver(self.deposit_id)
+        rec_video = record_resolver.resolve(dep_video['recid'])[1]
+        # sync deposit --> record
+        dep_video._sync_record_files(record=rec_video)
+        dep_video.commit()
+        rec_video.commit()
+        db.session.commit()
+
+    def on_success(self, *args, **kwargs):
+        pass
+
+    def _update_record(self, *args, **kwargs):
+        pass

--- a/cds/modules/migrator/cli.py
+++ b/cds/modules/migrator/cli.py
@@ -26,7 +26,7 @@
 from __future__ import absolute_import, print_function
 
 import json
-from datetime import datetime
+import warnings
 
 import click
 from flask import current_app
@@ -39,6 +39,10 @@ from invenio_sequencegenerator.api import Sequence
 from .tasks import clean_record
 
 from ...modules.deposit.api import Project, Video
+
+warnings.warn(
+    "The migrator module is now deprecated. Use it at your own risk!",
+    DeprecationWarning)
 
 
 def load_records(sources, source_type, eager):

--- a/cds/modules/migrator/records.py
+++ b/cds/modules/migrator/records.py
@@ -32,12 +32,11 @@ import os
 import shutil
 import tempfile
 from copy import deepcopy
-from datetime import datetime, timedelta
 
 import arrow
 from cds_dojson.marc21 import marc21
 from cds_dojson.marc21.utils import create_record
-from cds_sorenson.api import get_closest_aspect_ratio
+from cds_sorenson.api import get_all_distinct_qualities
 from celery.utils.log import get_task_logger
 from flask import current_app
 from invenio_accounts.models import User
@@ -768,19 +767,15 @@ class CDSRecordDumpLoader(RecordDumpLoader):
 
     @classmethod
     def _create_missing_subformats(cls, record, deposit):
-        """Crete missing subformats."""
+        """Create missing subformats."""
         # get master
         master = CDSVideosFilesIterator.get_master_video_file(deposit)
         if not master:
             return
 
-        # get the preset info from sorenson
         ratio = master['tags']['display_aspect_ratio']
         max_width = int(master['tags']['width'])
         max_height = int(master['tags']['height'])
-
-        if ratio not in current_app.config['CDS_SORENSON_PRESETS']:
-            ratio = get_closest_aspect_ratio(max_height, max_width)
 
         assert ratio in current_app.config['CDS_SORENSON_PRESETS']
         preset = current_app.config['CDS_SORENSON_PRESETS'][ratio]

--- a/cds/modules/migrator/tasks.py
+++ b/cds/modules/migrator/tasks.py
@@ -24,6 +24,8 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 """Record migration special."""
 
+import warnings
+
 from celery import shared_task
 from invenio_db import db
 from invenio_migrator.proxies import current_migrator
@@ -31,6 +33,10 @@ from invenio_migrator.proxies import current_migrator
 from ..deposit.api import deposit_video_resolver
 from ..records.resolver import record_resolver
 from ..webhooks.tasks import TranscodeVideoTask
+
+warnings.warn(
+    "The migrator module is now deprecated. Use it at your own risk!",
+    DeprecationWarning)
 
 
 class TranscodeVideoTaskQuiet(TranscodeVideoTask):

--- a/cds/modules/migrator/utils.py
+++ b/cds/modules/migrator/utils.py
@@ -23,10 +23,16 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 """Migration utils."""
 
+import warnings
+
 from flask import current_app
 
 from invenio_pidstore.fetchers import FetchedPID
 from ..records.providers import CDSReportNumberProvider
+
+warnings.warn(
+    "The migrator module is now deprecated. Use it at your own risk!",
+    DeprecationWarning)
 
 
 def process_fireroles(fireroles):

--- a/requirements.pinned.txt
+++ b/requirements.pinned.txt
@@ -23,7 +23,7 @@ cairocffi==0.8.0          # via cairosvg
 cairosvg==1.0.22
 cchardet==2.1.1           # via invenio-previewer
 cds-dojson==0.6.0
-cds-sorenson==0.1.3
+cds-sorenson==0.1.5
 celery==3.1.25
 certifi==2017.11.5        # via requests
 cffi==1.11.2              # via cairocffi, cryptography

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ install_requires = [
     'Flask-WTF>=0.13.1',
     'Flask>=0.11.1',
     'cds-dojson>=0.6.0',
-    'cds-sorenson>=0.1.3',
+    'cds-sorenson>=0.1.5',
     'datacite>=0.2.1',
     'dcxml>=0.1.0',
     'idutils>=0.2.3',
@@ -173,6 +173,9 @@ setup(
         'console_scripts': [
             'cds = cds.cli:cli',
         ],
+        'flask.commands': [
+            'subformats = cds.modules.maintenance.cli:subformats',
+        ],
         'invenio_admin.views': [
             'cds_admin = '
             'cds.modules.announcements.admin:announcements_adminview',
@@ -250,6 +253,7 @@ setup(
         'invenio_celery.tasks': [
             'cds_celery_tasks = cds.modules.webhooks.tasks',
             'cds_migration_tasks = cds.modules.migrator.tasks',
+            'cds_maintenance_tasks = cds.modules.maintenance.tasks',
         ],
         'invenio_webhooks.receivers': [
             'avc = cds.modules.webhooks.receivers:AVCWorkflow',

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -38,12 +38,14 @@ import jsonresolver
 from datetime import datetime
 
 from os.path import dirname, join
+
+from cds_sorenson.api import _get_quality_preset
+
 from cds.factory import create_app
 from cds.modules.deposit.api import Project
 from cds.modules.redirector.views import api_blueprint \
     as cds_api_blueprint
 from cds.modules.webhooks.receivers import CeleryAsyncReceiver
-from cds_sorenson.api import get_preset_id
 from cds_sorenson.error import InvalidResolutionError
 from celery import chain
 from celery import group
@@ -752,14 +754,14 @@ def mock_sorenson():
                         max_height=None, max_width=None):
         # Check if options are valid
         try:
-            get_preset_id(preset_name, aspect_ratio, max_height=max_height,
-                          max_width=max_width)
+            ar, preset_config = _get_quality_preset(preset_name, aspect_ratio,
+                                                    max_height, max_width)
         except InvalidResolutionError as e:
             raise e
 
         # just copy file
         shutil.copyfile(input_file, '{0}.mp4'.format(output_file))
-        return '1234'
+        return '1234', ar, preset_config
 
     mock.patch(
         'cds.modules.webhooks.tasks.start_encoding'

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -208,23 +208,26 @@ def get_object_count(download=True, frames=True, transcode=True):
 def get_tag_count(download=True, metadata=True, frames=True, transcode=True,
                   is_local=False):
     """Get number of ObjectVersionTags, based on executed tasks."""
-    # download: event_id, uri_origin, context_type, media_type, preview
+    # download: _event_id, uri_origin, context_type, media_type, preview
     tags_download = 5
     if is_local:
-        # uri_origin doesn't exists
+        # uri_origin doesn't exists if not downloaded
         tags_download = tags_download - 1
 
     # metadata
     tags_extract_metadata = len(ExtractMetadataTask.format_keys) + \
         len(ExtractMetadataTask.stream_keys)
 
+    # transcode
+    # number of keys inside object `tags` (basically, the number of tags)
+    tags_keys = 14
+
     return sum([
         tags_download if download else 0,
         tags_extract_metadata if download and metadata else 0,
         ((10 * 4) + 3) if frames else 0,
         # count the presets with width x height < 640x320 (video resolution)
-        # FIXME 13
-        ((len(get_presets_applied())) * 14) - 2 if transcode else 0,
+        (len(get_presets_applied())) * tags_keys if transcode else 0,
     ])
 
 

--- a/tests/unit/test_deposit.py
+++ b/tests/unit/test_deposit.py
@@ -133,7 +133,7 @@ def test_publish_process_files(api_app, db, location):
     for i in range(number_of_slaves):
         slave_obj = ObjectVersion.create(
             bucket=bucket,
-            key='slave{}.mp4'.format(i + 1),
+            key='{0}.mp4'.format(i + 1),
             _file_id=FileInstance.create())
         ObjectVersionTag.create(slave_obj, 'master', master_obj.version_id)
         ObjectVersionTag.create(slave_obj, 'media_type', 'video')

--- a/tests/unit/test_ffmpeg.py
+++ b/tests/unit/test_ffmpeg.py
@@ -37,7 +37,6 @@ from cds.modules.ffmpeg.ffmpeg import _refactoring_metadata
 from cds.modules.ffmpeg.errors import (FrameExtractionExecutionError,
                                        FrameExtractionInvalidArguments,
                                        MetadataExtractionExecutionError)
-from cds_sorenson.api import get_available_aspect_ratios
 
 
 def test_error_report(datadir):
@@ -183,12 +182,3 @@ def test_ffprobe_all(online_video):
     format_keys = ['filename', 'nb_streams', 'format_name', 'format_long_name',
                    'start_time', 'duration', 'size', 'bit_rate', 'tags']
     assert all([key in information['format'] for key in format_keys])
-
-
-def test_aspect_ratio(video, online_video):
-    """Test calculation of video's aspect ratio."""
-    for video in [video, online_video]:
-        metadata = ff_probe_all(video)['streams'][0]
-        for aspect_ratio in [ff_probe(video, 'display_aspect_ratio'),
-                             metadata['display_aspect_ratio']]:
-            assert aspect_ratio in get_available_aspect_ratios()

--- a/tests/unit/test_maintenance.py
+++ b/tests/unit/test_maintenance.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CDS.
+# Copyright (C) 2018 CERN.
+#
+# CDS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CDS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CDS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test cds maintenance."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+
+from cds.modules.maintenance.subformats import create_all_missing_subformats, \
+    create_all_subformats, create_subformat
+from mock import patch
+
+
+def _fill_video_subformats(qualities):
+    return [dict(tags=dict(preset_quality=q)) for q in qualities]
+
+
+@patch('cds.modules.maintenance.subformats.get_all_distinct_qualities')
+def test_subformats_input_validation(sorenson_all_qualities):
+    """Test subformats module inputs."""
+    with pytest.raises(Exception):
+        create_all_missing_subformats('otherid', 'value')
+        create_subformat('otherid', 'value', '')
+        create_all_subformats('otherid', 'value')
+
+        create_subformat('recid', 'value', None)
+        sorenson_all_qualities.return_value = ['240p', '360p', '480p']
+        create_subformat('recid', 'value', '720p')
+
+
+@patch('cds.modules.maintenance.subformats.chain')
+@patch('cds.modules.records.api.CDSVideosFilesIterator.get_video_subformats')
+@patch('cds.modules.maintenance.subformats.can_be_transcoded')
+@patch('cds.modules.maintenance.subformats.get_all_distinct_qualities')
+@patch('cds.modules.maintenance.subformats._get_master_video')
+@patch('cds.modules.maintenance.subformats._resolve_deposit')
+def test_create_all_missing_subformats(resolve_deposit, get_master_video,
+                                       sorenson_all_qualities,
+                                       sorenson_can_transcode,
+                                       video_subformats, _):
+    """Test method to create missing subformats."""
+    # set up
+    resolve_deposit.return_value = None, 'dep_uuid'
+    get_master_video.return_value = dict(
+        version_id='uuid_version'), '16:9', '', ''
+
+    # test no missing subformats
+    video_subformats.return_value = _fill_video_subformats(
+        ['240p', '360p', '480p'])
+    sorenson_all_qualities.return_value = ['240p', '360p', '480p']
+    sorenson_can_transcode.return_value = True
+    sorenson_can_transcode.side_effect = None
+    assert not create_all_missing_subformats('recid', 2)
+
+    # test 480p missing, 720p not valid
+    video_subformats.return_value = _fill_video_subformats(['240p', '360p'])
+    sorenson_all_qualities.return_value = ['240p', '360p', '480p', '720p']
+
+    def all_but_highest(q, ar, w, h):
+        return q != '720p'
+    sorenson_can_transcode.side_effect = all_but_highest
+    assert create_all_missing_subformats('recid', 2) == ['480p']
+
+    # test all missing
+    video_subformats.return_value = []
+    sorenson_all_qualities.return_value = ['240p', '360p', '480p', '720p']
+    sorenson_can_transcode.return_value = True
+    sorenson_can_transcode.side_effect = None
+    assert sorted(create_all_missing_subformats('recid', 2)) == sorted(
+        ['240p', '360p', '480p', '720p'])
+
+
+@patch('cds.modules.maintenance.subformats.MaintenanceTranscodeVideoTask')
+@patch('cds.modules.maintenance.subformats.can_be_transcoded')
+@patch('cds.modules.maintenance.subformats.get_all_distinct_qualities')
+@patch('cds.modules.maintenance.subformats._get_master_video')
+@patch('cds.modules.maintenance.subformats._resolve_deposit')
+def test_create_subformat(resolve_deposit, get_master_video,
+                          sorenson_all_qualities, sorenson_can_transcode, _):
+    """Test method to recreate a specific subformat quality."""
+    # set up
+    resolve_deposit.return_value = None, 'dep_uuid'
+    get_master_video.return_value = dict(
+        version_id='uuid_version'), '16:9', '', ''
+    sorenson_all_qualities.return_value = ['240p', '360p', '480p', '720p',
+                                           '1080p']
+
+    # test valid quality
+    sorenson_can_transcode.return_value = dict(quality='360p')
+    sorenson_can_transcode.side_effect = None
+    assert create_subformat('recid', 'value', '360p') == dict(quality='360p')
+
+    # test not valid quality
+    def all_but_highest(q, ar, w, h):
+        return q != '720p'
+    sorenson_can_transcode.side_effect = all_but_highest
+    assert not create_subformat('recid', 'value', '720p')
+
+
+@patch('cds.modules.maintenance.subformats.chain')
+@patch('cds.modules.maintenance.subformats.can_be_transcoded')
+@patch('cds.modules.maintenance.subformats.get_all_distinct_qualities')
+@patch('cds.modules.maintenance.subformats._get_master_video')
+@patch('cds.modules.maintenance.subformats._resolve_deposit')
+def test_recreate_all_subformats(resolve_deposit, get_master_video,
+                                 sorenson_all_qualities,
+                                 sorenson_can_transcode, _):
+    """Test method to create missing subformats."""
+    # set up
+    resolve_deposit.return_value = None, 'dep_uuid'
+    get_master_video.return_value = dict(
+        version_id='uuid_version'), '16:9', '', ''
+    sorenson_all_qualities.return_value = ['240p', '360p', '480p', '720p',
+                                           '1080p']
+
+    # test no subformats possible, should never happen
+    sorenson_can_transcode.return_value = False
+    assert not create_all_subformats('recid', 2)
+
+    # test recreate subformat but highest
+    def all_but_highest(q, ar, w, h):
+        return q != '1080p'
+    sorenson_can_transcode.side_effect = all_but_highest
+    assert sorted(create_all_subformats('recid', 2)) == sorted(
+        ['240p', '360p', '480p', '720p'])
+
+    # test recreate all subformats
+    sorenson_can_transcode.return_value = True
+    sorenson_can_transcode.side_effect = None
+    assert sorted(create_all_subformats('recid', 2)) == sorted(
+        ['240p', '360p', '480p', '720p', '1080p'])

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -62,7 +62,7 @@ from cds.modules.migrator.utils import cern_movie_to_video_pid_fetcher
 from helpers import load_json, get_frames, get_migration_streams
 
 
-@pytest.mark.skip(reason='Wait fix cds-dojson')
+@pytest.mark.skip(reason='Wait fix cds-dojson. Deprecated module.')
 def test_record_files_migration(app, location, script_info, datadir):
     """Test CDS records and files migrations."""
     runner = CliRunner()
@@ -94,6 +94,7 @@ def test_record_files_migration(app, location, script_info, datadir):
     assert record['_files'][0]['doctype'] == 'CTH_FILE'
 
 
+@pytest.mark.skip(reason='Deprecated module.')
 def test_migrate_pids(app, location, datadir, users):
     """Test migrate pids."""
     data = load_json(datadir, 'cds_records_demo_1_project.json')
@@ -111,6 +112,7 @@ def test_migrate_pids(app, location, datadir, users):
     10,   # normal number of frames
     100,  # force migrator to rebuild frames
 ])
+@pytest.mark.skip(reason='Deprecated module.')
 def test_migrate_record(frames_required, api_app, location, datadir, es,
                         users):
     """Test migrate date."""
@@ -352,6 +354,7 @@ def test_migrate_record(frames_required, api_app, location, datadir, es,
     assert record_video['title']['title'] == 'test'
 
 
+@pytest.mark.skip(reason='Deprecated module.')
 def test_sequence_number_update_after_migration(app, location, script_info, current_year):
     """Test sequence number update after migration."""
     # simulate a import of record < now(year)
@@ -401,6 +404,7 @@ def test_sequence_number_update_after_migration(app, location, script_info, curr
     assert len(TemplateDefinition.query.all()) == 2
 
 
+@pytest.mark.skip(reason='Deprecated module.')
 def test_retry_run_extracted_metadata(app):
     """Test retry is working properly."""
     with mock.patch.object(
@@ -410,6 +414,7 @@ def test_retry_run_extracted_metadata(app):
             CDSRecordDumpLoader._run_extracted_metadata(master={}, retry=1)
 
 
+@pytest.mark.skip(reason='Deprecated module.')
 def test_multiple_pid_for_movie(current_year):
     """Check multiple pid for movie and videoclip."""
     cern_video = 'CERN-VIDEO-{0}'.format(current_year)
@@ -442,6 +447,7 @@ def test_multiple_pid_for_movie(current_year):
     assert data['report_number'] == [cern_footage]
 
 
+@pytest.mark.skip(reason='Deprecated module.')
 def test_subformat_creation_if_missing(api_app, location, datadir, es, users):
     """Test subformat creation if missing."""
     # [[ migrate the video ]]

--- a/tests/unit/test_webhook_receivers.py
+++ b/tests/unit/test_webhook_receivers.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import, print_function
 import json
 
 import mock
-from cds_sorenson.api import get_available_preset_qualities
+from cds_sorenson.api import get_all_distinct_qualities
 from flask import url_for
 from flask_principal import UserNeed, identity_loaded
 from flask_security import current_user
@@ -219,7 +219,7 @@ def test_avc_workflow_receiver_pass(api_app, db, api_project, access_token,
     bucket_id = video_1['_buckets']['deposit']
     video_size = 5510872
     master_key = 'test.mp4'
-    slave_keys = ['slave_{0}.mp4'.format(quality)
+    slave_keys = ['{0}.mp4'.format(quality)
                   for quality in get_presets_applied()
                   if quality != '1024p']
     with api_app.test_request_context():
@@ -250,7 +250,7 @@ def test_avc_workflow_receiver_pass(api_app, db, api_project, access_token,
         assert data['tags']['uri_origin'] == online_video
         assert data['key'] == master_key
         assert 'version_id' in data
-        assert data.get('presets') == get_available_preset_qualities()
+        assert data.get('presets') == get_all_distinct_qualities()
         assert 'links' in data  # TODO decide with links are needed
 
         assert ObjectVersion.query.count() == get_object_count()
@@ -474,7 +474,7 @@ def test_avc_workflow_receiver_local_file_pass(
         version_id=local_file).one().bucket_id
     video_size = 5510872
     master_key = 'test.mp4'
-    slave_keys = ['slave_{0}.mp4'.format(quality)
+    slave_keys = ['{0}.mp4'.format(quality)
                   for quality in get_presets_applied().keys()
                   if quality != '1024p']
     with api_app.test_request_context():
@@ -506,7 +506,7 @@ def test_avc_workflow_receiver_local_file_pass(
         assert '_tasks' in data
         assert data['key'] == master_key
         assert 'version_id' in data
-        assert data.get('presets') == get_available_preset_qualities()
+        assert data.get('presets') == get_all_distinct_qualities()
         assert 'links' in data  # TODO decide with links are needed
 
         assert ObjectVersion.query.count() == get_object_count()
@@ -842,7 +842,8 @@ def test_avc_workflow_receiver_clean_video_transcode(
         assert ObjectVersion.query.count() == (
             get_object_count() + len(presets) + i
         )
-        assert ObjectVersionTag.query.count() == get_tag_count() + (i * 13)
+        # if changed, copy magic number 14 from helpers::get_tag_count
+        assert ObjectVersionTag.query.count() == get_tag_count() + (i * 14)
 
 
 @mock.patch('flask_login.current_user', mock_current_user)

--- a/tests/unit/test_webhook_tasks.py
+++ b/tests/unit/test_webhook_tasks.py
@@ -322,7 +322,7 @@ def test_transcode_and_undo(db, cds_depid, mock_sorenson):
     filesize = 1024
     filename = 'test.mp4'
     preset_quality = '480p'
-    new_filename = 'slave_{0}.mp4'.format(preset_quality)
+    new_filename = '{0}.mp4'.format(preset_quality)
     obj = ObjectVersion.create(bucket, key=filename,
                                stream=BytesIO(b'\x00' * filesize))
     ObjectVersionTag.create(obj, 'display_aspect_ratio', '16:9')
@@ -367,7 +367,7 @@ def test_transcode_2tasks_delete1(db, cds_depid, mock_sorenson):
     filesize = 1024
     filename = 'test.mp4'
     preset_qualities = ['480p', '720p']
-    new_filenames = ['slave_{0}.mp4'.format(p) for p in preset_qualities]
+    new_filenames = ['{0}.mp4'.format(p) for p in preset_qualities]
 
     (version_id, [task_s1, task_s2]) = transcode_task(
         bucket=bucket, filesize=filesize, filename=filename,

--- a/tests/unit/test_webhook_views.py
+++ b/tests/unit/test_webhook_views.py
@@ -267,7 +267,8 @@ def check_video_transcode_restart(api_app, event_id, access_token,
 
     # Create + restart transcode (clean + create)
     assert ObjectVersion.query.count() == get_object_count() + 2
-    assert ObjectVersionTag.query.count() == get_tag_count() + 13
+    # if changed, copy magic number 14 from helpers::get_tag_count
+    assert ObjectVersionTag.query.count() == get_tag_count() + 14
 
     # check extracted metadata is there
     record = RecordMetadata.query.get(video_1_id)


### PR DESCRIPTION
* use the new cds_sorenson api to transcode videos also in case of
unsopported aspect ratio
* remove `slave` filename
* create new maintenance module to allow subformat creation by using the
shell or the command line
* closes #1520