### PR TITLE
records: fix related records queries

### DIFF
--- a/cds/modules/records/templates/cds_records/record_detail.html
+++ b/cds/modules/records/templates/cds_records/record_detail.html
@@ -39,13 +39,13 @@
 {%- endblock page_footer %}
 
 {%- block page_body %}
-  {% set refer_query = "and -recid:%s" % record['recid'] %}
+  {% set refer_query = "AND -recid:%s" % record['recid'] %}
   {% if record['keywords'] %}
     {% set keywords = [] %}
     {% for keyword in record['keywords'] %}
       {% set keywords = keywords.append(keyword['name']) %}
     {% endfor %}
-    {% set refer_query = 'keywords.name:"%s" %s' % ('" or keywords.name:"'.join(keywords), refer_query) %}
+    {% set refer_query = '( keywords.name:"%s" %s )' % ('" OR keywords.name:"'.join(keywords), refer_query) %}
   {% else %}
     {% set refer_query = "category:%s %s" % (record['category'], refer_query) %}
   {% endif %}


### PR DESCRIPTION
* Lucene syntax requires that operator, like AND or OR, are uppercase to
  be considered as such. Also to adding parenthesis to the keywords
  makes the query more meaningful.