### PR TITLE
search: Revert back disable url handler

### DIFF
--- a/cds/modules/home/templates/cds_home/home.html
+++ b/cds/modules/home/templates/cds_home/home.html
@@ -6,7 +6,6 @@
     <div id="cds-featured-video" class="cds-home-video-featured bg-b">
       <!-- List group -->
       <invenio-search
-        disable-url-handler="true"
         search-endpoint='{{ config.FRONTPAGE_FEATURED_QUERY }}'
       >
         <div class="text-center">
@@ -36,7 +35,6 @@
         </div>
         <!-- List group -->
         <invenio-search
-          disable-url-handler="true"
           search-endpoint='{{ config.FRONTPAGE_RECENT_QUERY }}'
         >
           <div class="text-center">

--- a/cds/modules/records/templates/cds_records/record_detail.html
+++ b/cds/modules/records/templates/cds_records/record_detail.html
@@ -77,7 +77,6 @@
       </div>
       <!-- List group -->
       <invenio-search
-        disable-url-handler="true"
         search-endpoint='{{ config.CDS_RECORDS_RELATED_QUERY % refer_query }}'
       >
         <div class="text-center">

--- a/cds/modules/search_ui/templates/cds_search_ui/search.html
+++ b/cds/modules/search_ui/templates/cds_search_ui/search.html
@@ -14,7 +14,6 @@
 {%- block body_inner %}
 <div id="invenio-search">
   <invenio-search
-   disable-url-handler="true"
    search-endpoint="{{ config.SEARCH_UI_SEARCH_API }}"
    search-extra-params='{% if config.SEARCH_UI_SEARCH_EXTRA_PARAMS %}{{config.SEARCH_UI_SEARCH_EXTRA_PARAMS|tojson}}{% endif %}'
    search-hidden-params='{% if search_hidden_params %}{{search_hidden_params|tojson}}{% endif %}'


### PR DESCRIPTION
* `disable-url-handler` config disables all
   url parameters and thus deep links and
   search is broken. It was added in the first
   place just to hide the page size from url.