### PR TITLE
Fix initial video rendition

### DIFF
--- a/cds/modules/previewer/templates/cds_previewer/macros/player.html
+++ b/cds/modules/previewer/templates/cds_previewer/macros/player.html
@@ -17,7 +17,8 @@
           fluid: true
           {% endif %}
         },
-        isEmbeddable: true
+        isEmbeddable: true,
+        initialRendition: 'first'
       });
       // Preload
       player.source = {

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -533,7 +533,7 @@ def video_record_metadata(db, project_published, extra_metadata):
                             master=master_id,
                             preset_quality='{}p'.format(qualities[i]),
                             width=1000,
-                            height=1000,
+                            height=qualities[i],
                             smil=True,
                             video_bitrate=123456, ),
                         version_id=slave_id,)


### PR DESCRIPTION
The fix it's basically moving the 720p video subformat at the top in the smill file.
If there is no 720p video subformat then then it will load the 480p. 
If the 480p subformat is missing also then it will leave the smill file as it is.

Closes #1570