### PR TITLE
config: change no-reply email to no-reply@cern.ch

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -62,7 +62,7 @@ CDS_ENV_TEST = False
 #: Email address for admins.
 CDS_ADMIN_EMAIL = "cds-admin@cern.ch"
 #: Email address for no-reply.
-NOREPLY_EMAIL = "cds-no-reply@cern.ch"
+NOREPLY_EMAIL = "no-reply@cern.ch"
 MAIL_SUPPRESS_SEND = True
 
 ###############################################################################


### PR DESCRIPTION
Signed-off-by: Sebastian Witowski <witowski.sebastian@gmail.com>