### PR TITLE
search: fix search ui error

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -191,6 +191,7 @@ SEARCH_DOC_TYPE_DEFAULT = None
 SEARCH_ELASTIC_KEYWORD_MAPPING = {}
 # SEARCH UI JS TEMPLATES
 # SEARCH_UI_JSTEMPLATE_RESULTS = 'templates/cds_search_ui/results.html'
+SEARCH_UI_JSTEMPLATE_ERROR = 'templates/cds_search_ui/error.html'
 
 # Angular template for featured
 SEARCH_UI_VIDEO_FEATURED = 'templates/cds/video/featured.html'

--- a/cds/modules/deposit/templates/cds_deposit/index.html
+++ b/cds/modules/deposit/templates/cds_deposit/index.html
@@ -77,7 +77,7 @@
         </div>
       </div>
       <invenio-search-error
-        template="{{ url_for('static', filename='templates/invenio_search_ui/error.html') }}"
+        template="{{ url_for('static', filename='config.SEARCH_UI_JSTEMPLATE_ERROR') }}"
         message="{{ _('Search failed.') }}">
       </invenio-search-error>
     </div> <!-- ./row -->

--- a/cds/modules/search_ui/static/templates/cds_search_ui/error.html
+++ b/cds/modules/search_ui/static/templates/cds_search_ui/error.html
@@ -1,0 +1,6 @@
+<div ng-show='vm.invenioSearchError.name && vm.invenioSearchErrorResults.message'>
+  <div class="alert alert-danger">
+    <i class="fa fa-bolt"></i>
+    <strong translate>Error:</strong> {{ vm.invenioSearchErrorResults.message }}
+  </div>
+</div>


### PR DESCRIPTION
* Sometimes there was an empty error panel shown
  in search results. Now also checking the message
  of the error not to be empty.

closes #1560