### PR TITLE
previewer: add missing video extensions

### DIFF
--- a/cds/modules/files/receivers.py
+++ b/cds/modules/files/receivers.py
@@ -37,4 +37,6 @@ def on_download_rename_file(sender, obj):
     if master_version_id:
         master_obj = as_object_version(master_version_id)
         filename_no_ext = splitext(master_obj.key)[0]
-        obj.key = '{}-{}'.format(filename_no_ext, obj.key)
+        # master filename is the report number
+        if filename_no_ext not in obj.key:
+            obj.key = '{}-{}'.format(filename_no_ext, obj.key)

--- a/cds/modules/previewer/extensions/video.py
+++ b/cds/modules/previewer/extensions/video.py
@@ -32,17 +32,17 @@ from flask import render_template
 class VideoExtension(object):
     """Previewer extension for videos."""
 
-    previewable_extensions = ['mp4', 'webm', 'mov', 'avi', 'mpg']
+    previewable_extensions = ['mp4', 'm4v', 'webm', 'mov', 'avi', 'mpg', 'flv',
+                              'ts']
+    _file_exts = ['.{0}'.format(ext) for ext in previewable_extensions]
 
     def __init__(self, template=None):
         """Init video previewer."""
         self.template = template
 
-    @staticmethod
-    def can_preview(file):
+    def can_preview(self, file):
         """Determine if the given file can be previewed."""
-        return file.is_local() and file.has_extensions('.mp4', '.webm',
-                                                       '.mov', '.avi', '.mpg')
+        return file.is_local() and file.has_extensions(*self._file_exts)
 
     def preview(self, file):
         """Render appropriate template with embed flag."""


### PR DESCRIPTION
* add missing file extensions for video master files to be able to play
  the video.
* avoid prepending report number to filename when donwloading if already
  correctly named.