### PR TITLE
Fixtures: Additional responsible egroups for deposits

### DIFF
--- a/cds/modules/fixtures/data/categories.json
+++ b/cds/modules/fixtures/data/categories.json
@@ -25,7 +25,8 @@
     "types": ["FOOTAGE", "VIDEO"],
     "access": {
       "public": true,
-      "restricted": ["atlas-readaccess-active-members@cern.ch"]
+      "restricted": ["atlas-readaccess-active-members@cern.ch"],
+      "responsible": ["atlas-outreach-cds-video@cern.ch"]
     },
     "_record_type":  ["PROJECT"],
     "_access": {
@@ -37,7 +38,8 @@
     "types": ["VIDEO"],
     "access": {
       "public": true,
-      "restricted": []
+      "restricted": [],
+      "responsible": ["cms-virtual-visits@cern.ch"]
     },
     "_record_type":  ["PROJECT"],
     "_access": {
@@ -58,7 +60,8 @@
     "types": ["VIDEO"],
     "access": {
       "public": true,
-      "restricted": []
+      "restricted": [],
+      "responsible": ["service-winccoa@cern.ch"]
     },
     "_record_type":  ["PROJECT"]
   }


### PR DESCRIPTION
* Adds responsible egroups for ATLAS, CMS and SCADA in order to be able to share the deposit.

(closes #1583 )