### PR TITLE
previewer: fix paths creation for deposit preview

### DIFF
--- a/cds/modules/previewer/templates/cds_previewer/video/deposit.html
+++ b/cds/modules/previewer/templates/cds_previewer/video/deposit.html
@@ -33,7 +33,8 @@
   {%- set theo_config = {} -%}
 
   {# Strip eos path for the ``uri`` #}
-  {%- set path = file.file.obj.file.uri | replace(config.VIDEOS_XROOTD_PREFIX, '') %}
+  {%- set path = file.file.obj.file.uri | replace(config.VIDEOS_XROOTD_ENDPOINT, '') |
+                 replace(config.VIDEOS_LOCATION, '') %}
   {%- set source = config.WOWZA_VIDEO_URL | format(path) -%}
 
   {# Initialize theo player #}


### PR DESCRIPTION
* the path replace was looking for not existing string

* (closes #1735) (closes #1484)