### PR TITLE
player: option to activate subtitles by default

### DIFF
--- a/cds/modules/fixtures/data/pages/faq.html
+++ b/cds/modules/fixtures/data/pages/faq.html
@@ -51,6 +51,7 @@ To simplify, this makes you appear as two different users on our side, when you 
   <dt>start=5</dt><dd>this parameter starts playing the video at the 5th second.</dd>
   <dt>end=30</dt><dd>this parameter stops playing the video at the 30th second.</dd>
   <dt>subtitlesOff=1</dt><dd>this parameter turns off the subtitles of the video (if they are available).</dd>
+  <dt>subtitles=[lang]</dt><dd>this parameter activates the subtitles automatically. [lang] should be the short code for the available language, e.g. en.</dd>
   <dt>loop=1</dt><dd>this parameter plays the video in a loop.</dd>
   <dt>responsive=1</dt><dd>this parameter indicates that the video should fill the container and should be responsive.</dd>
 </dl>
@@ -65,5 +66,3 @@ To simplify, this makes you appear as two different users on our side, when you 
 <li>audiovisual.productions.service@cern.ch for questions related to videos, photos and audios</li>
 <li>cds.support@cern.ch for technical help related directly to the Videos platform of CERN Document Server.</li>
 </ul>
-
-

--- a/cds/modules/previewer/templates/cds_previewer/macros/player.html
+++ b/cds/modules/previewer/templates/cds_previewer/macros/player.html
@@ -59,6 +59,9 @@
             src: '{{ uri }}',
             label: '{{ lang }}',
             srclang: '{{ lang }}',
+            {% if embed_config.subtitles and embed_config.subtitles == lang %}
+            default: true,
+            {% endif %}
           },
           {% endfor %}
         ],


### PR DESCRIPTION
Adds option to activate subtitles by default on embedded videos.
Tested in cdslabs_qa, it works.