### PR TITLE
deposit: remove old user email when present

### DIFF
--- a/cds/modules/invenio_deposit/api.py
+++ b/cds/modules/invenio_deposit/api.py
@@ -188,6 +188,8 @@ class Deposit(Record):
         args = [lca.dumps(), first.dumps(), self.dumps()]
         for arg in args:
             del arg["$schema"], arg["_deposit"]
+            # pop optional removed key `current_user_mail` when present
+            arg.get("_cds", {}).pop("current_user_mail", None)
         args.append({})
         m = Merger(*args)
         try:


### PR DESCRIPTION
* the `_cds.current_user_mail` has been removed, however it might still be present in some previous records' revisions. This makes the publishing of editing videos fail. When the `_cds.current_user_mail` is found while publishing, it is ignored.