### PR TITLE
support uploading additional video files

### DIFF
--- a/Bruno Collection - CDS Videos Publish Video.json
+++ b/Bruno Collection - CDS Videos Publish Video.json
@@ -79,7 +79,7 @@
         "params": [],
         "body": {
           "mode": "json",
-          "json": "{\n    \"$schema\": \"https://localhost:5000/schemas/deposits/records/videos/project/project-v1.0.0.json\",\n    \"_access\": {\n          \"update\": [\n          \"admin@test.ch\",\n          \"your-egroup@cern.ch\"\n        ],\n      \"read\": [ // If you want to restrict the project, add access read\n            \"your-egroup@cern.ch\"\n        ]\n    },\n    // Add category and type\n    \"category\": \"ATLAS\",\n    \"type\": \"VIDEO\"\n}",
+          "json": "{\n    \"_access\": {\n          \"update\": [\n          \"admin@test.ch\",\n          \"your-egroup@cern.ch\"\n        ],\n      \"read\": [ // If you want to restrict the project, add access read\n            \"your-egroup@cern.ch\"\n        ]\n    },\n    // Add category and type\n    \"category\": \"ATLAS\",\n    \"type\": \"VIDEO\"\n}",
           "formUrlEncoded": [],
           "multipartForm": []
         },
@@ -111,7 +111,7 @@
         "params": [],
         "body": {
           "mode": "json",
-          "json": "{\n   \"$schema\":\"https://localhost:5000/schemas/deposits/records/videos/video/video-v1.0.0.json\",\n   \"_project_id\":\"{{project_id}}\",\n   \"title\":\n      {\n         \"title\":\"your_title\"\n      },\n   \"_access\": {\n      \"read\": [\n            \"your-egroup@cern.ch\"\n      ]\n   },\n   \"vr\": false,\n   \"featured\": false,\n   \"language\": \"en\",\n   \"contributors\": [\n         {\n            \"name\": \"Surname, Name\",\n            \"ids\": [\n               {\n                     \"value\": \"cern id\",\n                     \"source\": \"cern\"\n               }\n            ],\n            \"email\": \"test@cern.ch\",\n            \"role\": \"Co-Producer\"\n         }\n   ],\n   \"description\": \"Description\",\n   \"date\": \"2024-11-12\",\n   \"keywords\":[\n      {\n         \"name\": \"keyword\",\n         \"value\": {\n               \"name\": \"keyword\"\n         }\n      },\n      {\n         \"name\": \"keyword2\",\n         \"value\": {\n               \"name\": \"keyword2\"\n         }\n      }\n   ],\n   \"related_links\":[\n      {\n         \"name\": \"related link\",\n         \"url\": \"https://relatedlink\"\n      }\n   ]\n}",
+          "json": "{\n   \"_project_id\":\"{{project_id}}\",\n   \"language\":\"en\",\n      \"title\":\n      {\n         \"title\":\"your_title\"\n      },\n   \"_access\": {\n      \"read\": [\n            \"your-egroup@cern.ch\"\n      ]\n   },\n   \"vr\": false,\n   \"featured\": false,\n   \"language\": \"en\",\n   \"contributors\": [\n         {\n            \"name\": \"Surname, Name\",\n            \"ids\": [\n               {\n                     \"value\": \"cern id\",\n                     \"source\": \"cern\"\n               }\n            ],\n            \"email\": \"test@cern.ch\",\n            \"role\": \"Co-Producer\"\n         }\n   ],\n   \"description\": \"Description\",\n   \"date\": \"2024-11-12\",\n   \"keywords\":[\n      {\n         \"name\": \"keyword\",\n         \"value\": {\n               \"name\": \"keyword\"\n         }\n      },\n      {\n         \"name\": \"keyword2\",\n         \"value\": {\n               \"name\": \"keyword2\"\n         }\n      }\n   ],\n   \"related_links\":[\n      {\n         \"name\": \"related link\",\n         \"url\": \"https://relatedlink\"\n      }\n   ]\n}",
           "formUrlEncoded": [],
           "multipartForm": []
         },
@@ -200,7 +200,13 @@
       "request": {
         "url": "{{baseURL}}/api/files/{{bucket_id}}/{{additional_file}}",
         "method": "PUT",
-        "headers": [],
+        "headers": [
+          {
+            "name": "X-Invenio-File-Tags",
+            "value": "context_type=additional_file",
+            "enabled": true
+          }
+        ],
         "params": [],
         "body": {
           "mode": "json",
@@ -284,9 +290,6 @@
         "allow": true
       }
     },
-    "ignore": [
-      "node_modules",
-      ".git"
-    ]
+    "ignore": ["node_modules", ".git"]
   }
 }

--- a/README.rst
+++ b/README.rst
@@ -258,11 +258,6 @@ Step 1: Create a Project
      - **Location**
      - **Description**
      - **Required/Optional**
-   * - **$schema**
-     - string
-     - body
-     - Schema URL for the project creation.
-     - Required
    * - **category**
      - string
      - body
@@ -307,7 +302,6 @@ To restrict the project, add ``_access/read``:
 .. code-block:: json
 
    {
-      "$schema": "https://localhost:5000/schemas/deposits/records/videos/project/project-v1.0.0.json",
       "_access": {
             "update": [
             "admin@test.ch",
@@ -379,11 +373,6 @@ Step 2: Create a Video
      - **Location**
      - **Description**
      - **Required/Optional**
-   * - **$schema**
-     - string
-     - body
-     - Schema URL for video creation.
-     - Required
    * - **_project_id**
      - string
      - body
@@ -423,7 +412,7 @@ Step 2: Create a Video
      - string
      - body
      - Language of the video.
-     - Optional
+     - Required
    * - **featured**
      - boolean
      - body
@@ -447,7 +436,6 @@ To restrict the video, add ``_access/read``. The ``_access/update`` will be the 
 .. code-block:: json
 
    {
-      "$schema":"https://localhost:5000/schemas/deposits/records/videos/video/video-v1.0.0.json",
       "_project_id":"{{project_id}}",
       "title":
          {
@@ -495,7 +483,8 @@ To restrict the video, add ``_access/read``. The ``_access/update`` will be the 
             "name": "related link",
             "url": "https://relatedlink"
          }
-      ]
+      ],
+      "language": "en"
    }
 
 **Response:**  
@@ -604,6 +593,10 @@ Step 5: (Optional) Upload Additional File
 **Request:**  
 
 ``PUT`` ``{{baseURL}}/api/files/{{bucket_id}}/{{additional_file}}``
+
+**Headers:**  
+
+- ``X-Invenio-File-Tags: context_type=additional_file``
 
 **Parameters:**
 

--- a/cds/modules/deposit/api.py
+++ b/cds/modules/deposit/api.py
@@ -862,15 +862,7 @@ class Video(CDSDeposit):
                 subtitle_obj_key = "{}_{}.vtt".format(
                     self["report_number"][0], match.group("iso_lang")
                 )
-                obj = ObjectVersion.create(
-                    bucket=subtitle_obj.bucket,
-                    key=subtitle_obj_key,
-                    _file_id=subtitle_obj.file_id,
-                )
-                # copy tags to the newly created object version
-                for tag in subtitle_obj.tags:
-                    tag.object_version = obj
-                subtitle_obj.remove()
+                subtitle_obj.key = subtitle_obj_key
 
     def _rename_master_file(self, master_file):
         """Rename master file."""

--- a/cds/modules/deposit/static/templates/cds_deposit/deposits.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/deposits.html
@@ -39,6 +39,7 @@
                     <h3>Click here to select videos to upload</h3>
                   </div>
                   <p class="cds-deposit-box-upload-description">You can also <strong>Drag & Drop</strong> video files here</p>
+                  <p class="text-muted mt-20">supported files <mark>{{ $ctrl.videoExtensions }}</mark></p>
                 </div>
               </div>
             </div>

--- a/cds/modules/deposit/static/templates/cds_deposit/types/video/uploader.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/video/uploader.html
@@ -9,7 +9,7 @@
 <!-- Master video and subformats -->
 <div ng-show="$ctrl.files.length > 0" class="panel panel-default">
   <div class="panel-heading">
-    Master & Subformats files
+    Main & Subformats files
   </div>
   <table class="table">
     <tr>
@@ -224,12 +224,12 @@
   </table>
 </div>
 <!-- Subtitles -->
-<!-- Other -->
-<div ng-show="($ctrl.files | removeBy:'context_type':'poster' |removeBy:'context_type':'master' | removeBy:'context_type':'subtitle' || []).length > 0" class="panel panel-default">
+<!-- Additional files -->
+<div class="panel panel-default">
   <div class="panel-heading">
-    Other files
+    Additional files
   </div>
-  <div class="panel-heading">
+  <div ng-show="($ctrl.files | removeBy:'context_type':'poster' |removeBy:'context_type':'master' | removeBy:'context_type':'subtitle' || []).length > 0"  class="panel-heading">
     <div class="row">
       <div class="col-sm-6">
         <p ng-show="$ctrl.files.length > 0" class="text-muted">
@@ -242,7 +242,7 @@
       </div>
     </div>
   </div>
-  <table class="table">
+  <table ng-show="($ctrl.files | removeBy:'context_type':'poster' |removeBy:'context_type':'master' | removeBy:'context_type':'subtitle' || []).length > 0" class="table">
     <tr>
       <th>Filename</th>
       <th>Size</th>
@@ -271,6 +271,31 @@
       </td>
     </tr>
   </table>
+  <!-- Upload Additional files -->
+  <div class="panel-body">
+    <div class="cds-deposit-box" ng-if="!$ctrl.cdsDepositCtrl.isPublished()">
+      <div 
+        ngf-drag-over-class="'cds-deposit-dragover'"
+        ngf-drop=""
+        ngf-change="$ctrl.addFiles($newFiles, $invalidFiles)"
+        ngf-select=""
+        ngf-model-options="{allowInvalid: false}"
+        ngf-max-size="500GB"
+        ngf-multiple="true"
+      >
+        <div class="pa-10 cds-deposit-box-upload-wrapper text-center">
+          <p class="cds-deposit-box-upload-icon mb-20">
+            <i class="fa fa-3x fa-files-o" aria-hidden="true"></i>
+          </p>
+          <div class="cds-deposit-box-upload-content">
+            <h4>Upload complimentary files for this video</h4>
+            <p class="cds-deposit-box-upload-description">Or Drag & Drop files</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- Upload Additional files -->
 </div>
 <hr class="my-20" />
 <!-- Error alert -->
@@ -283,36 +308,40 @@
   </ul>
 </div>
 <!-- Error alert -->
-<div class="cds-deposit-box" ng-if="!$ctrl.cdsDepositCtrl.isPublished()">
-  <div
-       ngf-drag-over-class="'cds-deposit-dragover'"
-       ngf-drop=""
-       ngf-change="$ctrl.addFiles($newFiles, $invalidFiles)"
-       ngf-select=""
-       ngf-model-options="{allowInvalid: false}"
-       ngf-max-size="500GB"
-       ngf-multiple="true"
-  >
-    <div class="pa-10 cds-deposit-box-upload-wrapper text-center">
-      <p class="cds-deposit-box-upload-icon mb-20">
-        <i class="fa fa-3x fa-files-o" aria-hidden="true"></i>
-      </p>
-      <div class="cds-deposit-box-upload-content">
-        <div class="cds-deposit-box-upload-title">
-          <h4>Upload complimentary files for this video</h4>
+
+<!-- Replacing Master Video File -->
+<div class="panel panel-default" ng-if="!$ctrl.cdsDepositCtrl.isPublished()">
+  <div class="panel-heading panel-heading-warning">
+    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Replace Video File
+  </div>
+  <div class="panel-body">
+    <div class="cds-deposit-box" >
+      <div 
+        ngf-drag-over-class="{accept: 'cds-deposit-dragover', delay:100}"
+        ngf-drop=""
+        ngf-change="$ctrl.replaceMasterFile($newFiles, $invalidFiles)"
+        ngf-select=""
+        ngf-model-options="{allowInvalid: false}"
+        ngf-max-size="500GB"
+        ngf-multiple="true"
+        ngf-accept="'{{$ctrl.cdsDepositsCtrl.videoExtensions}}'"
+        ngf-pattern="'{{$ctrl.cdsDepositsCtrl.videoExtensions}}'"
+      >
+        <div class="pa-10 cds-deposit-box-upload-wrapper text-center">
+          <p class="cds-deposit-box-upload-icon mb-20">
+            <i class="fa fa-2x fa-video-camera" aria-hidden="true"></i>
+          </p>
+          <div class="cds-deposit-box-upload-content">
+            <h4>To replace the video file, just upload a video here.</h4>
+            <p class="cds-deposit-box-upload-description">Or Drag & Drop files</p>
+          </div>
         </div>
-        <p class="cds-deposit-box-upload-description"> Or Drag & Drop files</p>
       </div>
     </div>
   </div>
-  <hr class="my-10" />
-  <div class="text-muted">
-    <h5 class="text-muted"><strong>Tips and suggestions</strong></h5>
-    <ul>
-      <li>To replace the video file, just upload another video.</li>
-    </ul>
-  </div>
 </div>
+
+
 <div ng-if="$ctrl.cdsDepositCtrl.isPublished()" class="cds-deposit-box text-muted">
   <h5 class="text-muted"><strong>Tips and suggestions</strong></h5>
   <ul>

--- a/cds/modules/records/static/templates/cds_records/video/downloads.html
+++ b/cds/modules/records/static/templates/cds_records/video/downloads.html
@@ -146,12 +146,12 @@
 </div>
 <!-- /Subtitles -->
 
-<!-- Additional files -->
-<div ng-if="(record.metadata._files | getAllFilesExcept: ['subtitle']).length > 1" class="cds-video-subformats bt bw-1 bc-gl pt-10 pb-10">
+ <!-- Additional video files -->
+ <div ng-if="(record.metadata._files | getFilesByType: ['video']).length > 1" class="cds-video-subformats bt bw-1 bc-gl pt-10 pb-10">
   <div class="row">
     <div class="col-md-12">
       <a class="f8 display-block" ng-click="showAllAdditionalFiles = !showAllAdditionalFiles">
-        Additional files
+        Additional video files
         <p class="pull-right mb-0">
           <span ng-show="showAllAdditionalFiles">
             <i class="fa f5 fa-angle-up"></i>
@@ -165,8 +165,8 @@
   </div>
   <div ng-show="record.metadata._files.length > 1 && showAllAdditionalFiles" class="cds-detail-download-box cds-detail-video-download-box mt-5">
     <div class="list-group">
-      <a title="{{file.key}}" ng-repeat="file in (record.metadata._files | getAllFilesExcept: ['subtitle'])" class="download-list-item-other" ng-href="{{ file.links.self | download }}" ng-hide="file.context_type == 'master'" target="_blank">
-        {{ file.key | ellipsis: 25 }}
+      <a title="{{file.key}}" ng-repeat="file in (record.metadata._files | getFilesByType: ['video'])" class="download-list-item-other" ng-href="{{ file.links.self | download }}" ng-hide="file.context_type == 'master'" target="_blank">
+        {{ file.key | middleEllipsis: 25 }}
         <span class="pull-right">
           <small>{{ file.size | bytesToHumanReadable }}</small>
         </span>
@@ -174,5 +174,36 @@
     </div>
   </div>
 </div>
-<!-- /Additional files -->
+<!-- /Additional video files -->
+
+<!-- Other files -->
+<div ng-if="(record.metadata._files | getAllFilesExcept: ['subtitle', 'video']).length > 0" class="cds-video-subformats bt bw-1 bc-gl pt-10 pb-10">
+  <div class="row">
+    <div class="col-md-12">
+      <a class="f8 display-block" ng-click="showAllAdditionalFiles = !showAllAdditionalFiles">
+        Other files
+        <p class="pull-right mb-0">
+          <span ng-show="showAllAdditionalFiles">
+            <i class="fa f5 fa-angle-up"></i>
+          </span>
+          <span ng-show="!showAllAdditionalFiles">
+            <i class="fa f5 fa-angle-down"></i>
+          </span>
+        </p>
+      </a>
+    </div>
+  </div>
+  <div ng-show="record.metadata._files.length > 1 && showAllAdditionalFiles" class="cds-detail-download-box cds-detail-video-download-box mt-5">
+    <div class="list-group">
+      <a title="{{file.key}}" ng-repeat="file in (record.metadata._files | getAllFilesExcept: ['subtitle', 'video'])" class="download-list-item-other" ng-href="{{ file.links.self | download }}" ng-hide="file.context_type == 'master'" target="_blank">
+        {{ file.key | middleEllipsis: 25 }}
+        <span class="pull-right">
+          <small>{{ file.size | bytesToHumanReadable }}</small>
+        </span>
+      </a>
+    </div>
+  </div>
+</div>
+<!-- /Other files -->
+
 <!-- /Download -->

--- a/cds/modules/theme/assets/bootstrap3/js/cds/module.js
+++ b/cds/modules/theme/assets/bootstrap3/js/cds/module.js
@@ -341,6 +341,24 @@ app.filter("ellipsis", function () {
   };
 });
 
+app.filter("middleEllipsis", function () {
+  return function (text, length) {
+    if (!text || text.length <= length) return text;
+
+    const dotIndex = text.lastIndexOf(".");
+    const hasExtension = dotIndex > 0;
+
+    if (hasExtension) {
+      const namePart = text.substring(0, dotIndex);
+      const extensionPart = text.substring(dotIndex);
+
+      return namePart.substr(0, length) + " [...]" + extensionPart;
+    }
+
+    return text.substr(0, length) + " [...]";
+  };
+});
+
 // Trust as html
 app.filter("trustHtml", [
   "$sce",
@@ -403,7 +421,7 @@ app.filter("getFilesByType", function () {
     }
 
     return files.filter(function (file) {
-      return types.indexOf(file.context_type) !== -1;
+      return types.indexOf(file.media_type) !== -1;
     });
   };
 });
@@ -429,7 +447,7 @@ app.filter("getAllFilesExcept", function () {
     }
 
     return files.filter(function (file) {
-      return types.indexOf(file.context_type) == -1;
+      return types.indexOf(file.media_type) == -1;
     });
   };
 });

--- a/cds/modules/theme/assets/bootstrap3/scss/cds/cds.scss
+++ b/cds/modules/theme/assets/bootstrap3/scss/cds/cds.scss
@@ -81,6 +81,10 @@ html, body {
   }
 }
 
+.panel-heading-warning {
+  background-color: $brand-warning !important;
+}
+
 .cds-deposit-metadata-extraction-alert {
   line-height: 33px;
   span {


### PR DESCRIPTION
**Current Behavior:**
- When a video file is uploaded as a complimentary (additional) file, it replaces the master file and triggers the workflow.
    ![Image](https://github.com/user-attachments/assets/dd4fb9c0-c871-46ae-bd6f-24920a53ff8c)
    ![Image](https://github.com/user-attachments/assets/bc872a33-a6cd-4689-b826-02291546c1d2)
All files are tagged as `subtitle` after upload
     ![Image](https://github.com/user-attachments/assets/7fe72759-c55d-403c-977b-0273273ffd6e)

**UI Changes:**
- Separated the functionality for uploading additional files and replacing the master file.
- Updated the UI to reflect these distinct behaviors:
    - Replacing the Master File: Continues to trigger the workflow as before.
    - Uploading Additional Files: Behaves as expected, uploads the file as an additional file without triggering the workflow.
     <img height="500" alt="Image" src="https://github.com/user-attachments/assets/60abcbd5-e710-4fab-83c3-37e946f5edc7" /> 
    <img height="550" alt="Image" src="https://github.com/user-attachments/assets/84af3868-6c3a-4faa-b6ed-a3a372258d9b" />
-  Landing page files are displaying in this order:
    - Other video formats
    - Thumbnails
    - Subtitles
    - Additional video files (new)
    - Other files (new)
    <img width="499" alt="Image" src="https://github.com/user-attachments/assets/f0e70daf-6232-4181-a574-f8a9def83033" />
**Backend Changes:**
- Modifed the `create_tags` method to support additional files, this also fixes the error when uploading the `poster.png` file.

