### PR TITLE
oauth: change app name

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   Tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [3.9]
@@ -49,7 +49,7 @@ jobs:
           sudo apt-get install ffmpeg
           ffmpeg -version
 
-      - name: Install ldap dependencies
+      - name: Install LDAP dependencies
         run: |
           sudo apt-get update
           sudo apt-get install libsasl2-dev libldap2-dev libssl-dev

--- a/cds/config.py
+++ b/cds/config.py
@@ -1140,10 +1140,10 @@ False value disabled the refresh.
 OAUTHCLIENT_CERN_OPENID_SESSION_KEY = "identity.cdsvideos_openid_provides"
 """Name of session key where CERN roles are stored."""
 
-REMOTE_APP_NAME = "cern_openid"
+REMOTE_APP_NAME = "cern_cdsvideos_openid"
 
 OAUTHCLIENT_CERN_OPENID_USERINFO_URL = (
-    "https://auth.cern.ch/auth/realms/cern/" "protocol/openid-connect/userinfo"
+    "https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/userinfo"
 )
 
 OAUTH_REMOTE_APP = copy.deepcopy(cern_openid.REMOTE_APP)
@@ -1156,11 +1156,11 @@ OAUTH_REMOTE_APP["params"].update(
         ),
         access_token_url=os.environ.get(
             "OAUTH_CERN_OPENID_ACCESS_TOKEN_URL",
-            "https://auth.cern.ch/auth/realms/cern/" "protocol/openid-connect/token",
+            "https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/token",
         ),
         authorize_url=os.environ.get(
             "OAUTH_CERN_OPENID_AUTHORIZE_URL",
-            "https://auth.cern.ch/auth/realms/cern/" "protocol/openid-connect/auth",
+            "https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/auth",
         ),
     )
 )
@@ -1190,7 +1190,7 @@ OAUTHCLIENT_CERN_OPENID_JWT_TOKEN_DECODE_PARAMS = dict(
     algorithms=["HS256", "RS256"],
 )
 
-OAUTHCLIENT_REMOTE_APPS = dict(cern_openid=OAUTH_REMOTE_APP)
+OAUTHCLIENT_REMOTE_APPS = dict(cern_cdsvideos_openid=OAUTH_REMOTE_APP)
 """CERN Openid Remote Application."""
 
 ## Needed for populating the user profiles when users login via CERN Openid

--- a/cds/modules/theme/templates/cds_theme/header.html
+++ b/cds/modules/theme/templates/cds_theme/header.html
@@ -75,7 +75,7 @@
                   <li><a href=" {{url_for_security('login', next=request.path)}}"><strong><i class="fa fa-sign-in"></i> {{_('Log in')}}</strong></a></li>
                 {%- else %}
                   <li>
-                    <a href="{{url_for('invenio_oauthclient.login', remote_app='cern_openid', next=request.path)}}">
+                    <a href="{{url_for('invenio_oauthclient.login', remote_app='cern_cdsvideos_openid', next=request.path)}}">
                        <strong><i class="fa fa-sign-in"></i> {{_('Log in')}}</strong>
                     </a>
                   </li>


### PR DESCRIPTION
* Change app name to avoid collisions with the cern_openid in invenio-oauthclient. Signals on_identity_* won't be called in Invenio module.