### PR TITLE
keywords: add missing source field used in old migrated records

### DIFF
--- a/cds/modules/records/serializers/schemas/common.py
+++ b/cds/modules/records/serializers/schemas/common.py
@@ -47,6 +47,7 @@ class KeywordsSchema(Schema):
 
     name = fields.Str()
     value = fields.Dict()
+    source = fields.Str()
 
     @validates_schema
     def validate_keyword_schema(self, data, **kwargs):


### PR DESCRIPTION
The source field was missing from marshmallow schema and this causing old migrated records unable to be published after editing. In the current version of the codebase the source is not kept but all keywords are added as free text.