### PR TITLE
subtitles: fix renaming on publish

### DIFF
--- a/cds/modules/deposit/api.py
+++ b/cds/modules/deposit/api.py
@@ -862,7 +862,15 @@ class Video(CDSDeposit):
                 subtitle_obj_key = "{}_{}.vtt".format(
                     self["report_number"][0], match.group("iso_lang")
                 )
-                subtitle_obj.key = subtitle_obj_key
+                obj = ObjectVersion.create(
+                    bucket=subtitle_obj.bucket,
+                    key=subtitle_obj_key,
+                    _file_id=subtitle_obj.file_id,
+                )
+                # copy tags to the newly created object version
+                for tag in subtitle_obj.tags:
+                    ObjectVersionTag.create_or_update(obj, tag.key, tag.value)
+                subtitle_obj.remove()
 
     def _rename_master_file(self, master_file):
         """Rename master file."""


### PR DESCRIPTION
Only this line changed from the master branch:
https://github.com/CERNDocumentServer/cds-videos/blob/main/cds/modules/deposit/api.py#L872

When removing the `subtitle_obj`, it was also removing the `ObjectVersionTag`s, so tags were not actually copied.
<img width="497" alt="Screenshot 2025-04-28 at 14 46 04" src="https://github.com/user-attachments/assets/8001037d-223a-4445-994b-b60b8d66f3a7" />
