### PR TITLE
schema: add related_identifiers and additonal titles/descriptions

### DIFF
--- a/cds/modules/deposit/mappings/os-v2/deposits/records/videos/video/video-v1.0.0.json
+++ b/cds/modules/deposit/mappings/os-v2/deposits/records/videos/video/video-v1.0.0.json
@@ -355,6 +355,54 @@
           },
           "department": {
             "type": "keyword"
+          },
+          "volumes": {
+            "type": "text"
+          }
+        }
+      },
+      "additional_titles": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "text"
+          },
+          "type": {
+            "type": "keyword"
+          },
+          "lang": {
+            "type": "keyword"
+          }
+        }
+      },
+      "additional_descriptions": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "text"
+          },
+          "type": {
+            "type": "keyword"
+          },
+          "lang": {
+            "type": "keyword"
+          }
+        }
+      },
+      "related_identifiers": {
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "type": "text"
+          },
+          "scheme": {
+            "type": "keyword"
+          },
+          "relation_type": {
+            "type": "keyword"
+          },
+          "resource_type": {
+            "type": "keyword"
           }
         }
       }

--- a/cds/modules/deposit/schemas/deposits/records/videos/video/video-v1.0.0.json
+++ b/cds/modules/deposit/schemas/deposits/records/videos/video/video-v1.0.0.json
@@ -198,7 +198,8 @@
         "properties": {
           "scheme": {
             "title": "Scheme of the identifier (Vocabulary)",
-            "type": "string"
+            "type": "string",
+            "enum": ["URL", "DOI", "CDS"]
           },
           "value": {
             "title": "Value of the identifier",
@@ -735,10 +736,201 @@
         "department": {
           "title": "CERN department.",
           "type": "string"
+        },
+        "volumes": {
+          "title": "Volume list for this record.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "title": "Fields that needs curation.",
       "type": "object"
+    },
+    "additional_titles": {
+      "description": "Additional record titles.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "description": "Additional title of the record.",
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["Subtitle", "Other", "TranslatedTitle", "AlternativeTitle"]
+          },
+          "lang": {
+            "type": "string",
+            "enum": [
+              "ar",
+              "ast",
+              "bg",
+              "ca",
+              "ch",
+              "cs",
+              "cy",
+              "da",
+              "de",
+              "el",
+              "en",
+              "en-fr",
+              "es",
+              "et",
+              "eu",
+              "fi",
+              "fr",
+              "ga",
+              "gd",
+              "gl",
+              "he",
+              "hi",
+              "hr",
+              "hu",
+              "it",
+              "lt",
+              "ja",
+              "ka",
+              "ko",
+              "kw",
+              "nb",
+              "nl",
+              "nn",
+              "no",
+              "pl",
+              "pt",
+              "rm",
+              "ro",
+              "ru",
+              "se",
+              "silent",
+              "sk",
+              "sl",
+              "sr",
+              "sv",
+              "tr",
+              "uk",
+              "ur",
+              "zh",
+              "zh_CN",
+              "zh_TW"
+            ]
+          }
+        }
+      }
+    },
+    "additional_descriptions": {
+      "description": "Additional descriptions for the record.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Descriptive content."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Abstract",
+              "Methods",
+              "Other",
+              "SeriesInformation",
+              "TableOfContents",
+              "TechnicalInfo"
+            ]
+          },
+          "lang": {
+            "type": "string",
+            "enum": [
+              "ar",
+              "ast",
+              "bg",
+              "ca",
+              "ch",
+              "cs",
+              "cy",
+              "da",
+              "de",
+              "el",
+              "en",
+              "en-fr",
+              "es",
+              "et",
+              "eu",
+              "fi",
+              "fr",
+              "ga",
+              "gd",
+              "gl",
+              "he",
+              "hi",
+              "hr",
+              "hu",
+              "it",
+              "lt",
+              "ja",
+              "ka",
+              "ko",
+              "kw",
+              "nb",
+              "nl",
+              "nn",
+              "no",
+              "pl",
+              "pt",
+              "rm",
+              "ro",
+              "ru",
+              "se",
+              "silent",
+              "sk",
+              "sl",
+              "sr",
+              "sv",
+              "tr",
+              "uk",
+              "ur",
+              "zh",
+              "zh_CN",
+              "zh_TW"
+            ]
+          }
+        }
+      }
+    },
+    "related_identifiers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["identifier", "scheme", "relation_type"],
+        "additionalProperties": false,
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "description": "The actual identifier (e.g., URL or DOI)."
+          },
+          "scheme": {
+            "type": "string",
+            "enum": ["URL", "DOI", "CDS", "Indico"],
+            "description": "The scheme describing the identifier type."
+          },
+          "relation_type": {
+            "type": "string",
+            "enum": ["IsPartOf", "IsVariantFormOf"],
+            "description": "Describes the relationship with the current record."
+          },
+          "resource_type": {
+            "type": "string",
+            "enum": ["Event", "ConferencePaper", "Report"],
+            "description": "Type of the related resource."
+          }
+        }
+      }
     }
   }
 }

--- a/cds/modules/records/mappings/os-v2/records/videos/video/video-v1.0.0.json
+++ b/cds/modules/records/mappings/os-v2/records/videos/video/video-v1.0.0.json
@@ -353,6 +353,54 @@
           },
           "department": {
             "type": "keyword"
+          },
+          "volumes": {
+            "type": "text"
+          }
+        }
+      },
+      "additional_titles": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "text"
+          },
+          "type": {
+            "type": "keyword"
+          },
+          "lang": {
+            "type": "keyword"
+          }
+        }
+      },
+      "additional_descriptions": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "text"
+          },
+          "type": {
+            "type": "keyword"
+          },
+          "lang": {
+            "type": "keyword"
+          }
+        }
+      },
+      "related_identifiers": {
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "type": "text"
+          },
+          "scheme": {
+            "type": "keyword"
+          },
+          "relation_type": {
+            "type": "keyword"
+          },
+          "resource_type": {
+            "type": "keyword"
           }
         }
       }

--- a/cds/modules/records/schemas/records/videos/video/video-v1.0.0.json
+++ b/cds/modules/records/schemas/records/videos/video/video-v1.0.0.json
@@ -209,7 +209,8 @@
         "properties": {
           "scheme": {
             "title": "Scheme of the identifier (Vocabulary)",
-            "type": "string"
+            "type": "string",
+            "enum": ["URL", "DOI", "CDS"]
           },
           "value": {
             "title": "Value of the identifier",
@@ -670,10 +671,201 @@
         "department": {
           "title": "CERN department.",
           "type": "string"
+        },
+        "volumes": {
+          "title": "Volume list for this record.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "title": "Fields that needs curation.",
       "type": "object"
+    },
+    "additional_titles": {
+      "description": "Additional record titles.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "description": "Additional title of the record.",
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["Subtitle", "Other", "TranslatedTitle", "AlternativeTitle"]
+          },
+          "lang": {
+            "type": "string",
+            "enum": [
+              "ar",
+              "ast",
+              "bg",
+              "ca",
+              "ch",
+              "cs",
+              "cy",
+              "da",
+              "de",
+              "el",
+              "en",
+              "en-fr",
+              "es",
+              "et",
+              "eu",
+              "fi",
+              "fr",
+              "ga",
+              "gd",
+              "gl",
+              "he",
+              "hi",
+              "hr",
+              "hu",
+              "it",
+              "lt",
+              "ja",
+              "ka",
+              "ko",
+              "kw",
+              "nb",
+              "nl",
+              "nn",
+              "no",
+              "pl",
+              "pt",
+              "rm",
+              "ro",
+              "ru",
+              "se",
+              "silent",
+              "sk",
+              "sl",
+              "sr",
+              "sv",
+              "tr",
+              "uk",
+              "ur",
+              "zh",
+              "zh_CN",
+              "zh_TW"
+            ]
+          }
+        }
+      }
+    },
+    "additional_descriptions": {
+      "description": "Additional descriptions for the record.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Descriptive content."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Abstract",
+              "Methods",
+              "Other",
+              "SeriesInformation",
+              "TableOfContents",
+              "TechnicalInfo"
+            ]
+          },
+          "lang": {
+            "type": "string",
+            "enum": [
+              "ar",
+              "ast",
+              "bg",
+              "ca",
+              "ch",
+              "cs",
+              "cy",
+              "da",
+              "de",
+              "el",
+              "en",
+              "en-fr",
+              "es",
+              "et",
+              "eu",
+              "fi",
+              "fr",
+              "ga",
+              "gd",
+              "gl",
+              "he",
+              "hi",
+              "hr",
+              "hu",
+              "it",
+              "lt",
+              "ja",
+              "ka",
+              "ko",
+              "kw",
+              "nb",
+              "nl",
+              "nn",
+              "no",
+              "pl",
+              "pt",
+              "rm",
+              "ro",
+              "ru",
+              "se",
+              "silent",
+              "sk",
+              "sl",
+              "sr",
+              "sv",
+              "tr",
+              "uk",
+              "ur",
+              "zh",
+              "zh_CN",
+              "zh_TW"
+            ]
+          }
+        }
+      }
+    },
+    "related_identifiers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["identifier", "scheme", "relation_type"],
+        "additionalProperties": false,
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "description": "The actual identifier (e.g., URL or DOI)."
+          },
+          "scheme": {
+            "type": "string",
+            "enum": ["URL", "DOI", "CDS", "Indico"],
+            "description": "The scheme describing the identifier type."
+          },
+          "relation_type": {
+            "type": "string",
+            "enum": ["IsPartOf", "IsVariantFormOf"],
+            "description": "Describes the relationship with the current record."
+          },
+          "resource_type": {
+            "type": "string",
+            "enum": ["Event", "ConferencePaper", "Report"],
+            "description": "Type of the related resource."
+          }
+        }
+      }
     }
   },
   "title": "CDS Base Record Schema v1.0.0"

--- a/cds/modules/records/serializers/schemas/common.py
+++ b/cds/modules/records/serializers/schemas/common.py
@@ -160,11 +160,36 @@ class ExternalSystemIdentifiersField(StrictKeysSchema):
 class AlternateIdentifiersSchema(StrictKeysSchema):
     """Field alternate_identifiers."""
 
-    value = fields.Str()
-    schema = fields.Str()
+    value = fields.Str(required=True)
+    scheme = fields.Str(required=True)
 
 
 class CurationSchema(StrictKeysSchema):
     """Curation schema."""
+
     legacy_report_number = fields.Str()
     department = fields.Str()
+    volumes = fields.List(fields.Str())
+
+
+class AdditionalTitlesSchema(Schema):
+    """Additional titles schema."""
+
+    title = fields.Str()
+    type = fields.Str()
+    lang = fields.Str()
+
+
+class AdditionalDescriptionsSchema(Schema):
+    """Additional descriptions schema."""
+
+    description = fields.Str()
+    type = fields.Str()
+    lang = fields.Str()
+
+
+class RelatedIdentifiersSchema(Schema):
+    identifier = fields.Str(required=True)
+    scheme = fields.Str(required=True)
+    relation_type = fields.Str(required=True)
+    resource_type = fields.Str()

--- a/cds/modules/records/serializers/schemas/video.py
+++ b/cds/modules/records/serializers/schemas/video.py
@@ -25,6 +25,8 @@ from ....deposit.api import Video
 from ..fields.datetime import DateString
 from .common import (
     AccessSchema,
+    AdditionalTitlesSchema,
+    AdditionalDescriptionsSchema,
     AlternateIdentifiersSchema,
     BucketSchema,
     ContributorSchema,
@@ -34,6 +36,7 @@ from .common import (
     KeywordsSchema,
     LicenseSchema,
     OaiSchema,
+    RelatedIdentifiersSchema,
     RelatedLinksSchema,
     StrictKeysSchema,
     TitleSchema,
@@ -134,9 +137,6 @@ class VideoSchema(StrictKeysSchema):
     external_system_identifiers = fields.Nested(
         ExternalSystemIdentifiersField, many=True
     )
-    alternate_identifiers = fields.Nested(
-        AlternateIdentifiersSchema, many=True
-    )
     featured = fields.Boolean()
     internal_note = fields.Str()
     internal_categories = fields.Raw()
@@ -154,9 +154,17 @@ class VideoSchema(StrictKeysSchema):
     title = fields.Nested(TitleSchema, required=True)
     translations = fields.Nested(TranslationsSchema, many=True)
     type = fields.Str()
-    vr = fields.Boolean(),
+    vr = fields.Boolean()
     _curation = fields.Nested(CurationSchema)
-
+    additional_titles = fields.List(fields.Nested(AdditionalTitlesSchema))
+    additional_descriptions = fields.List(fields.Nested(AdditionalDescriptionsSchema))
+    alternate_identifiers = fields.Nested(
+        AlternateIdentifiersSchema, many=True
+    )
+    related_identifiers = fields.Nested(
+        RelatedIdentifiersSchema, many=True
+    )
+    
     # Preservation fields
     location = fields.Str()
     original_source = fields.Str()


### PR DESCRIPTION
closes https://github.com/CERNDocumentServer/cds-videos/issues/2035
closes https://github.com/CERNDocumentServer/cds-videos/issues/2031

- `volumes` is added to `_curation`
- `additional_titles` added
- `additional_descriptions` added
- `related_identifiers` added

