### PR TITLE
tests: fix failing tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,13 @@ name: CI
 
 on:
   push:
-    branches: main
+    branches:
+      - main
   pull_request:
-    branches: main
+    branches: 
+      - main
+      - additional-files
+
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron: "0 4 * * 6"

--- a/tests/unit/test_fixtures.py
+++ b/tests/unit/test_fixtures.py
@@ -91,7 +91,7 @@ def test_fixture_categories(app, script_info, db, es, location):
     res = runner.invoke(cli_categories, [], obj=script_info)
     assert res.exit_code == 0
     categories = RecordMetadata.query.all()
-    assert len(categories) == 7
+    assert len(categories) == 8
     for category in categories:
         assert "VIDEO" in category.json["types"]
 

--- a/tests/unit/test_schema_datacite.py
+++ b/tests/unit/test_schema_datacite.py
@@ -43,6 +43,7 @@ def test_video_metadata_tranform(app, video_record_metadata, recid_pid):
             {"creatorName": "pluto"},
             {"creatorName": "zio paperino"},
         ],
+        "contributors": [],
         "dates": [{"date": "2017-03-02", "dateType": "Issued"}],
         "descriptions": [
             {


### PR DESCRIPTION
Since we have the new category `LECTURES`  test `test_fixture_categories` was failing.
And we added [`contributors`](https://github.com/CERNDocumentServer/cds-videos/blob/additional-files/cds/modules/records/serializers/schemas/datacite.py#L56) to datacite schema, `test_video_metadata_tranform` was failing.

Tests are fixed now