### PR TITLE
auth: allow external accounts to login and restrict upload

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -1173,7 +1173,7 @@ OAUTHCLIENT_CERN_OPENID_USERINFO_URL = os.environ.get(
     "https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/userinfo",
 )
 
-OAUTHCLIENT_CERN_OPENID_ALLOWED_ROLES = ["cern-user"]
+OAUTHCLIENT_CERN_OPENID_ALLOWED_ROLES = ["cern-user", "authenticated-user"]
 
 OAUTHCLIENT_CERN_OPENID_REFRESH_TIMEDELTA = timedelta(minutes=-5)
 """Default interval for refreshing CERN extra data (e.g. groups).

--- a/cds/modules/deposit/views.py
+++ b/cds/modules/deposit/views.py
@@ -25,6 +25,7 @@
 """CDS interface."""
 
 
+from cds.modules.ldap.decorators import require_upload_permission
 from flask import (
     Blueprint,
     abort,
@@ -118,6 +119,7 @@ def to_links_js(pid, deposit=None, dep_type=None):
 
 @blueprint.route("/deposit/reportnumbers/new", methods=["GET", "POST"])
 @login_required
+@require_upload_permission()
 def reserve_report_number():
     """Form to reserver a new report number."""
     if not has_read_record_eos_path_permission(current_user, None):
@@ -156,6 +158,7 @@ def reserve_report_number():
     "/deposit/reportnumbers/assign/<string:depid>", methods=["GET", "POST"]
 )
 @login_required
+@require_upload_permission()
 def assign_report_number(depid):
     """Form to reserver a new report number."""
     if not has_read_record_eos_path_permission(current_user, None):

--- a/cds/modules/home/views.py
+++ b/cds/modules/home/views.py
@@ -25,6 +25,8 @@ from flask_menu import current_menu
 from invenio_cache.decorators import cached_unless_authenticated
 from invenio_i18n import lazy_gettext as _
 
+from ..records.permissions import has_upload_permission
+
 blueprint = Blueprint(
     "cds_home",
     __name__,
@@ -58,4 +60,5 @@ def init_menu(app):
         "invenio_deposit_ui.index",
         _("Upload"),
         order=2,
+        visible_when=lambda: has_upload_permission()
     )

--- a/cds/modules/invenio_deposit/utils.py
+++ b/cds/modules/invenio_deposit/utils.py
@@ -28,6 +28,7 @@
 from flask import request
 from invenio_oauth2server import require_api_auth, require_oauth_scopes
 
+from cds.modules.ldap.decorators import require_upload_permission
 from .scopes import write_scope
 
 
@@ -84,6 +85,7 @@ def check_oauth2_scope(can_method, *myscopes):
 
     def check(record, *args, **kwargs):
         @require_api_auth()
+        @require_upload_permission()
         @require_oauth_scopes(*myscopes)
         def can(self):
             return can_method(record)

--- a/cds/modules/invenio_deposit/views/ui.py
+++ b/cds/modules/invenio_deposit/views/ui.py
@@ -27,6 +27,7 @@
 
 from copy import deepcopy
 
+from cds.modules.ldap.decorators import require_upload_permission
 from flask import Blueprint, current_app, render_template, request
 from flask_login import login_required
 from invenio_pidstore.errors import PIDDeletedError
@@ -73,12 +74,14 @@ def create_blueprint(endpoints):
 
     @blueprint.route("/deposit")
     @login_required
+    @require_upload_permission()
     def index():
         """List user deposits."""
         return render_template(current_app.config["DEPOSIT_UI_INDEX_TEMPLATE"])
 
     @blueprint.route("/deposit/new")
     @login_required
+    @require_upload_permission()
     def new():
         """Create new deposit."""
         deposit_type = request.values.get("type")

--- a/cds/modules/ldap/decorators.py
+++ b/cds/modules/ldap/decorators.py
@@ -33,3 +33,20 @@ def needs_authentication(func):
             abort(401)
         return func(*args, **kwargs)
     return decorated_api_view
+
+
+def require_upload_permission():
+    """Restrict access using the has_upload_permission check."""
+    def decorator(f):
+        from cds.modules.records.permissions import has_upload_permission
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            if not current_user.is_authenticated:
+                abort(401)
+
+            if not has_upload_permission():
+                abort(403)
+
+            return f(*args, **kwargs)
+        return decorated_function
+    return decorator

--- a/cds/modules/records/permissions.py
+++ b/cds/modules/records/permissions.py
@@ -25,7 +25,7 @@
 
 from flask import current_app
 from flask_security import current_user
-from invenio_access import Permission
+from invenio_access import Permission, action_factory
 from invenio_files_rest.models import Bucket, MultipartObject, ObjectVersion
 from invenio_records_files.api import FileObject
 from invenio_records_files.models import RecordsBuckets
@@ -34,6 +34,8 @@ from ..invenio_deposit.permissions import action_admin_access
 from .api import CDSRecord as Record
 from .utils import get_user_provides, is_deposit, is_record, lowercase_value
 
+
+upload_access_action = action_factory("videos-upload-access")
 
 def files_permission_factory(obj, action=None):
     """Permission for files are always based on the type of bucket.
@@ -228,7 +230,7 @@ class RecordPermission(object):
     def create(cls, record, action, user=None):
         """Create a record permission."""
         if action in cls.create_actions:
-            return cls(record, allow, user)
+            return cls(record, has_upload_permission, user)
         elif action in cls.read_actions:
             return cls(record, has_read_record_permission, user)
         elif action in cls.read_eos_path_actions:
@@ -359,3 +361,8 @@ def has_admin_permission(user=None, record=None):
     """
     # Allow administrators
     return Permission(action_admin_access).can()
+
+
+def has_upload_permission(*args, **kwargs):
+    """Return permission to allow only cern users."""
+    return Permission(upload_access_action).can()

--- a/cds/modules/records/permissions.py
+++ b/cds/modules/records/permissions.py
@@ -336,6 +336,9 @@ def has_update_permission(user, record):
     """Check if user has update access to the record."""
     user_id = int(user.get_id()) if user.is_authenticated else None
 
+    if not has_upload_permission():
+        return False
+
     # Allow owners
     deposit_creator = record.get("_deposit", {}).get("created_by", -1)
     if user_id == deposit_creator:

--- a/scripts/setup
+++ b/scripts/setup
@@ -41,9 +41,12 @@ cds users create test@test.ch -a --password=123456
 # Create an admin user
 cds users create admin@test.ch -a --password=123456
 cds roles create admin
+cds roles create cern-user
+cds roles add test@test.ch cern-user
 cds roles add admin@test.ch admin
 cds access allow deposit-admin-access role admin
 cds access allow superuser-access role admin
+cds access allow videos-upload-access role cern-user
 
 # Create a default files location
 cds files location --default videos /tmp/files

--- a/setup.cfg
+++ b/setup.cfg
@@ -225,6 +225,7 @@ invenio_oauth2server.scopes =
     deposit_actions = cds.modules.invenio_deposit.scopes:actions_scope
 invenio_access.actions =
     deposit_admin_access = cds.modules.invenio_deposit.permissions:action_admin_access
+    upload_access_action = cds.modules.records.permissions:upload_access_action
 invenio_db.models =
     cds_migration_models = cds.modules.legacy.models
 

--- a/tests/unit/test_external_user.py
+++ b/tests/unit/test_external_user.py
@@ -1,0 +1,372 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CDS.
+# Copyright (C) 2025 CERN.
+#
+# CDS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CDS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CDS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+
+"""Tests for external user permissions."""
+
+import json
+from io import BytesIO
+
+from flask import url_for
+from flask_principal import AnonymousIdentity, UserNeed, identity_loaded
+from flask_security import current_user, login_user, logout_user
+from helpers import prepare_videos_for_publish
+from invenio_access import Permission
+from invenio_access.models import ActionRoles
+from invenio_accounts.models import Role, User
+
+from cds.modules.deposit.api import deposit_video_resolver
+from cds.modules.records.permissions import (
+    has_upload_permission,
+    record_permission_factory,
+    upload_access_action,
+)
+
+
+def test_has_upload_permission_external_user(app, external_user):
+    """Test that external user without cern-user role cannot upload."""
+    with app.test_request_context():
+        user = User.query.get(external_user)
+        login_user(user)
+
+        # Test has_upload_permission function directly
+        permission = Permission(upload_access_action)
+        assert not permission.can()
+
+        # Test has_upload_permission helper function
+        assert not has_upload_permission()
+
+
+def test_has_upload_permission_cern_user(app, users):
+    """Test that authenticated user with cern-user role can upload."""
+    with app.test_request_context():
+        user = User.query.get(users[0])
+        login_user(user)
+
+        # Test has_upload_permission function directly
+        permission = Permission(upload_access_action)
+        assert permission.can()
+
+        # Test has_upload_permission helper function
+        assert has_upload_permission()
+
+
+def test_record_create_permission_external_user(app, external_user, deposit_metadata):
+    """Test record create permission for external user without role."""
+    with app.test_request_context():
+        user = User.query.get(external_user)
+        login_user(user)
+
+        # Test creating a record permission
+        factory = record_permission_factory(record=deposit_metadata, action="create")
+        assert not factory.can()
+
+
+def test_project_rest_api_external_user_can_create(
+    api_app, external_user, deposit_metadata, json_partial_project_headers
+):
+    """Test project creation via REST API for external user without role."""
+    with api_app.test_client() as client:
+        user = User.query.get(external_user)
+        login_user(user)
+
+        # Try to create a project via REST API
+        resp = client.post(
+            url_for("invenio_deposit_rest.project_list"),
+            data=json.dumps(deposit_metadata),
+            headers=json_partial_project_headers,
+        )
+        # Should be forbidden (403) because user doesn't have upload permission
+        assert resp.status_code == 403
+
+
+def test_video_rest_api_external_user(
+    api_app, external_user, video_deposit_metadata, json_partial_project_headers
+):
+    """Test video creation via REST API for external user without role."""
+    with api_app.test_client() as client:
+        user = User.query.get(external_user)
+        login_user(user)
+
+        # Try to create a video via REST API
+        resp = client.post(
+            url_for("invenio_deposit_rest.video_list"),
+            data=json.dumps(video_deposit_metadata),
+            headers=json_partial_project_headers,
+        )
+        # Should be forbidden (403) because user doesn't have upload permission
+        assert resp.status_code == 403
+
+
+def test_anonymous_user_has_upload_permission(app):
+    """Test that anonymous users cannot upload."""
+    with app.test_request_context():
+        # No user logged in
+        logout_user()
+
+        # Test has_upload_permission function directly
+        permission = Permission(upload_access_action)
+        assert not permission.can()
+
+        # Test has_upload_permission helper function
+        assert not has_upload_permission()
+
+
+def test_external_user_role_assignment(app, db, external_user):
+    """Test that we can dynamically add cern-user role to external user."""
+    with app.test_request_context():
+        user = User.query.get(external_user)
+        login_user(user)
+
+        # Initially should not have upload permission
+        assert not has_upload_permission()
+
+        # Add cern-user role
+        datastore = app.extensions["security"].datastore
+        cern_user_role = Role.query.filter_by(name="cern-user").first()
+        if not cern_user_role:
+            cern_user_role = Role(name="cern-user")
+            db.session.add(
+                ActionRoles(action=upload_access_action.value, role=cern_user_role)
+            )
+        datastore.add_role_to_user(user, cern_user_role)
+        db.session.commit()
+
+        # Need to logout and login again for role to take effect
+        logout_user()
+        login_user(user)
+
+        # Now should have upload permission
+        assert has_upload_permission()
+
+
+def test_published_video_access_control_external_user(
+    api_app, location, users, external_user, api_project
+):
+    """Test external user access to published video records."""
+
+    @identity_loaded.connect
+    def mock_identity_provides(sender, identity):
+        """Ensure external users have their email in identity for testing."""
+        if (
+            not isinstance(identity, AnonymousIdentity)
+            and current_user.is_authenticated
+        ):
+            # Add UserNeed with email for all authenticated users (including external users)
+            if (
+                current_user.email
+                and UserNeed(current_user.email) not in identity.provides
+            ):
+                identity.provides.add(UserNeed(current_user.email))
+
+    (_, video_1, video_2) = api_project
+    cern_user = User.query.filter_by(id=users[0]).first()
+    user2 = User.query.filter_by(id=users[1]).first()
+    ext_user = User.query.filter_by(id=external_user).first()
+
+    # Prepare videos for publishing
+    prepare_videos_for_publish([video_1, video_2])
+    vid1 = video_1["_deposit"]["id"]
+    vid2 = video_2["_deposit"]["id"]
+
+    with api_app.test_client() as client:
+        login_user(cern_user)
+
+        # Create restricted video (user2 access only)
+        video_1_metadata = dict(video_1)
+        for key in ["_files"]:
+            video_1_metadata.pop(key, None)
+        video_1_metadata["_access"] = {"read": [user2.email]}
+
+        resp = client.put(
+            url_for("invenio_deposit_rest.video_item", pid_value=vid1),
+            data=json.dumps(video_1_metadata),
+            headers=[
+                ("Content-Type", "application/vnd.video.partial+json"),
+                ("Accept", "application/json"),
+            ],
+        )
+        assert resp.status_code == 200
+
+        # Publish restricted video
+        url = url_for(
+            "invenio_deposit_rest.video_actions", pid_value=vid1, action="publish"
+        )
+        assert client.post(url).status_code == 202
+        rec_pid1, _ = deposit_video_resolver(vid1).fetch_published()
+
+        # Create restricted video (external user access only)
+        video_2_metadata = dict(video_2)
+        for key in ["_files"]:
+            video_2_metadata.pop(key, None)
+        video_2_metadata["_access"] = {"read": [ext_user.email]}
+
+        resp = client.put(
+            url_for("invenio_deposit_rest.video_item", pid_value=vid2),
+            data=json.dumps(video_2_metadata),
+            headers=[
+                ("Content-Type", "application/vnd.video.partial+json"),
+                ("Accept", "application/json"),
+            ],
+        )
+        assert resp.status_code == 200
+
+        # Publish restricted video (external user access only)
+        url = url_for(
+            "invenio_deposit_rest.video_actions", pid_value=vid2, action="publish"
+        )
+        assert client.post(url).status_code == 202
+        rec_pid2, _ = deposit_video_resolver(vid2).fetch_published()
+
+        # Test external user access
+        logout_user()
+        login_user(ext_user)
+
+        # External user should be blocked from video1
+        resp1 = client.get(
+            url_for("invenio_records_rest.recid_item", pid_value=rec_pid1.pid_value)
+        )
+        assert resp1.status_code in [403, 404]
+
+        # External user should access video2
+        resp2 = client.get(
+            url_for("invenio_records_rest.recid_item", pid_value=rec_pid2.pid_value)
+        )
+        assert resp2.status_code == 200
+        video_data = json.loads(resp2.data.decode("utf-8"))
+        assert "metadata" in video_data
+
+
+def test_external_user_deposit_operations(
+    api_app,
+    location,
+    external_user,
+    users,
+    deposit_metadata,
+    project_deposit_metadata,
+    video_deposit_metadata,
+    json_partial_project_headers,
+    json_partial_video_headers,
+):
+    """Tests for external user deposit operations and permissions."""
+    with api_app.test_request_context():
+        # Setup: Create project and video as CERN user
+        cern_user = User.query.get(users[0])
+        login_user(cern_user)
+        
+        with api_app.test_client() as client:
+            # Create project
+            resp = client.post(
+                url_for("invenio_deposit_rest.project_list"),
+                data=json.dumps(project_deposit_metadata),
+                headers=json_partial_project_headers,
+            )
+            assert resp.status_code == 201
+            project_data = json.loads(resp.data.decode("utf-8"))
+            project_id = project_data["metadata"]["_deposit"]["id"]
+            
+            # Create video
+            video_deposit_metadata["_project_id"] = project_id
+            resp = client.post(
+                url_for("invenio_deposit_rest.video_list"),
+                data=json.dumps(video_deposit_metadata),
+                headers=json_partial_video_headers,
+            )
+            assert resp.status_code == 201
+            video_data = json.loads(resp.data.decode("utf-8"))
+            video_id = video_data["metadata"]["_deposit"]["id"]
+            
+            # Switch to external user for testing
+            logout_user()
+            ext_user = User.query.get(external_user)
+            login_user(ext_user)
+            
+            # Test 1: Project creation - should be forbidden
+            resp = client.post(
+                url_for("invenio_deposit_rest.project_list"),
+                data=json.dumps(deposit_metadata),
+                headers=json_partial_project_headers,
+            )
+            assert resp.status_code == 403
+            
+            # Test 2: Project item operations - should be forbidden
+            # GET project
+            resp = client.get(
+                url_for("invenio_deposit_rest.project_item", pid_value=project_id)
+            )
+            assert resp.status_code in [403, 404]
+            
+            # PUT project
+            resp = client.put(
+                url_for("invenio_deposit_rest.project_item", pid_value=project_id),
+                data=json.dumps(deposit_metadata),
+                headers=json_partial_project_headers,
+            )
+            assert resp.status_code == 403
+            
+            # DELETE project
+            resp = client.delete(
+                url_for("invenio_deposit_rest.project_item", pid_value=project_id)
+            )
+            assert resp.status_code == 403
+            
+            # Test 3: Project actions - should be forbidden
+            actions = ["publish", "edit", "discard"]
+            for action in actions:
+                resp = client.post(
+                    url_for(
+                        "invenio_deposit_rest.project_actions",
+                        pid_value=project_id,
+                        action=action,
+                    )
+                )
+                assert resp.status_code in [403, 404]
+            
+            # Test 4: File operations - should be forbidden
+            # GET files list
+            resp = client.get(
+                url_for("invenio_deposit_rest.project_files", pid_value=project_id)
+            )
+            assert resp.status_code in [403, 404]
+            
+            # POST file upload
+            resp = client.post(
+                url_for("invenio_deposit_rest.project_files", pid_value=project_id),
+                data={"file": (BytesIO(b"test content"), "test.txt")},
+            )
+            assert resp.status_code in [403, 404]
+            
+            # Test 5: Flows API - should be forbidden
+            flow_payload = {
+                "bucket_id": "test-bucket-id",
+                "deposit_id": video_id,
+                "key": "test-file.mp4",
+                "version_id": "test-version-id",
+            }
+            resp = client.post(
+                "/api/flows/",
+                data=json.dumps(flow_payload),
+                headers=json_partial_project_headers,
+            )
+            assert resp.status_code in [401, 403, 404]


### PR DESCRIPTION
In SSO application:
- Role `cern-user` should change to **not** `required`
- Add new role with `Minimum Level of Assurance` and identifier `authenticated-user`.
    - Enable: `This role is required to access my application` 
    - Enable: `This role applies to all authenticated users`

Permissions:
- Users should have `cern-user` to upload/create.
- This role is connected with action: upload_access_action

```bash
cds access allow videos-upload-access role cern-user
```

TODO
- [x] Write unit test 
- [x] Test restriction for all endpoints
- [x] Better naming for new SSO role
- [x] Hide `Upload` button from the top navbar
- [x] Restrict edit even if external users in the access.update