### PR TITLE
chapters: improve parsing with unique timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ tmp
 
 # local python version/venv
 .python-version
+
+# AI files
+CLAUDE.md

--- a/cds/modules/deposit/api.py
+++ b/cds/modules/deposit/api.py
@@ -77,7 +77,12 @@ from ..records.api import (
 )
 from ..records.minters import cds_doi_generator, is_local_doi, report_number_minter
 from ..records.resolver import record_resolver
-from ..records.utils import is_record, lowercase_value, parse_video_chapters, get_existing_chapter_frame_timestamps
+from ..records.utils import (
+    is_record,
+    lowercase_value,
+    parse_video_chapters,
+    get_existing_chapter_frame_timestamps,
+)
 from ..records.validators import PartialDraft4Validator
 from ..records.permissions import is_public
 from .errors import DiscardConflict
@@ -925,7 +930,7 @@ class Video(CDSDeposit):
         for curr, old in zip(current_chapters, old_chapters):
             if curr["seconds"] != old["seconds"]:
                 return True
-        
+
         if len(current_chapters) != len(get_existing_chapter_frame_timestamps(self)):
             # Chapters did not change, but chapter frames doesn't exist
             return True
@@ -950,7 +955,9 @@ class Video(CDSDeposit):
 
             payload = current_flow.payload.copy()
 
-            current_app.logger.info(f"Submitting ExtractChapterFramesTask with payload: {payload}")
+            current_app.logger.info(
+                f"Submitting ExtractChapterFramesTask with payload: {payload}"
+            )
 
             ExtractChapterFramesTask().s(**payload).apply_async()
 
@@ -975,7 +982,7 @@ class Video(CDSDeposit):
         old_record = None
         try:
             _, old_record = self.fetch_published()
-        except KeyError as e: # First publish (no pid key)
+        except KeyError as e:  # First publish (no pid key)
             pass
 
         try:

--- a/cds/modules/deposit/api.py
+++ b/cds/modules/deposit/api.py
@@ -918,14 +918,14 @@ class Video(CDSDeposit):
         old_description = old_record.get("description", "")
         old_chapters = parse_video_chapters(old_description)
 
-        # Compare chapter timestamps and titles
+        # Compare chapter timestamps
         if len(current_chapters) != len(old_chapters):
             return True
 
         for curr, old in zip(current_chapters, old_chapters):
-            if curr["seconds"] != old["seconds"] or curr["title"] != old["title"]:
+            if curr["seconds"] != old["seconds"]:
                 return True
-
+        
         if len(current_chapters) != len(get_existing_chapter_frame_timestamps(self)):
             # Chapters did not change, but chapter frames doesn't exist
             return True

--- a/cds/modules/fixtures/data/pages/faq.html
+++ b/cds/modules/fixtures/data/pages/faq.html
@@ -71,7 +71,7 @@ Each line should follow one of these formats:
 hh:mm:ss Title
 mm:ss Title
 </pre>
-<p>Make sure that the first timestamp starts with 00:00. When you publish your record, the chapters panel will be available automatically.</p>
+<p>Make sure that the first timestamp starts with 00:00. When you publish your video, we will process the description, and we will generate the chapters automatically. The generated chapters will be shown in the landing page of video under the section "Chapters".</p>
 
 <p><strong><a href="#embed-options" name="embed-options" class="cds-anchor">Are there special options for embedding a video?</a></strong></p>
 <p>Yes, there are several parameters that can be added to the embedding link in order to control the appearance of the embedded video. Below you can find the complete list:</p>

--- a/cds/modules/flows/tasks.py
+++ b/cds/modules/flows/tasks.py
@@ -1247,7 +1247,7 @@ def sync_records_with_deposit_files(self, deposit_id, max_retries=5, countdown=5
     if deposit_video.is_published():
         try:
             # sync deposit files <--> record files
-            deposit_video = deposit_video.edit().publish().commit()
+            deposit_video = deposit_video.edit().publish(extract_chapters=False).commit()
             record_pid, record = deposit_video.fetch_published()
             # save changes
             deposit_video.commit()

--- a/cds/modules/flows/tasks.py
+++ b/cds/modules/flows/tasks.py
@@ -898,15 +898,14 @@ class ExtractChapterFramesTask(AVCTask):
         """Ensure the bucket is unlocked for writing."""
         from invenio_files_rest.errors import BucketLockedError
 
-        if self.object_version.bucket.locked:
-            # If record was published we need to unlock the bucket
-            try:
-                return _method(*args, **kwargs)
-            except BucketLockedError:
-                self.object_version.bucket.locked = False
-                result = _method(*args, **kwargs)
-                self.object_version.bucket.locked = True
-                return result
+        # If record was published we need to unlock the bucket
+        try:
+            return _method(*args, **kwargs)
+        except BucketLockedError:
+            self.object_version.bucket.locked = False
+            result = _method(*args, **kwargs)
+            self.object_version.bucket.locked = True
+            return result
 
     def _create_chapter_frames(
         self,

--- a/cds/modules/flows/tasks.py
+++ b/cds/modules/flows/tasks.py
@@ -878,7 +878,12 @@ class ExtractChapterFramesTask(AVCTask):
             # Sync deposit and record files
             # Force session expire to avoid stale data issues
             db.session.expire_all()
-            sync_records_with_deposit_files(self.deposit_id)
+            deposit_video = deposit_video_resolver(self.deposit_id)
+            if deposit_video.is_published():
+                sync_records_with_deposit_files(self.deposit_id)
+            else:
+                deposit_video.commit()
+                db.session.commit()
 
         except Exception:
             db.session.rollback()

--- a/cds/modules/records/utils.py
+++ b/cds/modules/records/utils.py
@@ -524,6 +524,7 @@ def parse_video_chapters(description):
     pattern = r'(?:^|\n)\s*(\d{1,2}:(?:\d{1,2}:)?\d{1,2})\s*[-\s]*(.+?)(?=\n|$)'
     
     chapters = []
+    seen_timestamps = set()  # Unique seconds in timestamps
     matches = re.findall(pattern, description, re.MULTILINE)
     
     for timestamp_str, title in matches:
@@ -540,7 +541,8 @@ def parse_video_chapters(description):
             
         # Clean up title
         title = remove_html_tags(html_tag_remover, title).strip()
-        if title:
+        if title and total_seconds not in seen_timestamps:
+            seen_timestamps.add(total_seconds)
             chapters.append({
                 'timestamp': timestamp_str,
                 'seconds': total_seconds,

--- a/cds/modules/records/utils.py
+++ b/cds/modules/records/utils.py
@@ -497,39 +497,39 @@ def get_existing_chapter_frame_timestamps(deposit):
         tags = f.get("tags", {})
         if tags.get("is_chapter_frame") == "true":
             existing.add(float(tags.get("timestamp")))
-    return existing 
+    return existing
 
 
 def parse_video_chapters(description):
     """Parse YouTube-style chapter timestamps from video description.
-    
+
     Looks for patterns like:
     00:00 Introduction
     0:30 Getting Started
     1:23:45 Advanced Topics
-    
+
     Args:
         description (str): Video description text
-        
+
     Returns:
         list: List of chapter dicts with 'timestamp', 'seconds', and 'title' keys
     """
     html_tag_remover = HTMLTagRemover()
     if not description:
         return []
-    
+
     # Regex pattern to match timestamp formats:
     # - 0:00, 00:00, 0:0, 00:0, 0:00:00, 00:00:00, etc.
     # - Followed by optional space/tab and chapter title
-    pattern = r'(?:^|\n)\s*(\d{1,2}:(?:\d{1,2}:)?\d{1,2})\s*[-\s]*(.+?)(?=\n|$)'
-    
+    pattern = r"(?:^|\n)\s*(\d{1,2}:(?:\d{1,2}:)?\d{1,2})\s*[-\s]*(.+?)(?=\n|$)"
+
     chapters = []
     seen_timestamps = set()  # Unique seconds in timestamps
     matches = re.findall(pattern, description, re.MULTILINE)
-    
+
     for timestamp_str, title in matches:
         # Parse timestamp to seconds
-        time_parts = timestamp_str.split(':')
+        time_parts = timestamp_str.split(":")
         if len(time_parts) == 2:  # MM:SS format
             minutes, seconds = map(int, time_parts)
             total_seconds = minutes * 60 + seconds
@@ -538,29 +538,27 @@ def parse_video_chapters(description):
             total_seconds = hours * 3600 + minutes * 60 + seconds
         else:
             continue
-            
+
         # Clean up title
         title = remove_html_tags(html_tag_remover, title).strip()
         if title and total_seconds not in seen_timestamps:
             seen_timestamps.add(total_seconds)
-            chapters.append({
-                'timestamp': timestamp_str,
-                'seconds': total_seconds,
-                'title': title
-            })
-    
+            chapters.append(
+                {"timestamp": timestamp_str, "seconds": total_seconds, "title": title}
+            )
+
     # Sort chapters by timestamp
-    chapters.sort(key=lambda x: x['seconds'])
-    
+    chapters.sort(key=lambda x: x["seconds"])
+
     return chapters
 
 
 def seconds_to_timestamp(seconds):
     """Convert seconds to timestamp string (MM:SS or HH:MM:SS).
-    
+
     Args:
         seconds (int): Number of seconds
-        
+
     Returns:
         str: Formatted timestamp string
     """
@@ -568,7 +566,7 @@ def seconds_to_timestamp(seconds):
     hours = td.seconds // 3600
     minutes = (td.seconds % 3600) // 60
     secs = td.seconds % 60
-    
+
     if hours > 0:
         return f"{hours}:{minutes:02d}:{secs:02d}"
     else:

--- a/tests/unit/test_flows_tasks.py
+++ b/tests/unit/test_flows_tasks.py
@@ -584,6 +584,7 @@ def test_extract_chapter_frames_task(app, db, bucket, video, users):
     # Create a video object version
     obj = ObjectVersion.create(bucket=bucket, key="video.mp4", stream=open(video, "rb"))
     add_video_tags(obj)
+    master_version_id = obj.version_id
     db.session.commit()
     
     # Create a project and video deposit with short chapter timestamps
@@ -663,7 +664,7 @@ def test_extract_chapter_frames_task(app, db, bucket, video, users):
         # Verify all calls to _create_object had correct master_id
         for call_args in mock_create_object.call_args_list:
             kwargs = call_args.kwargs
-            assert kwargs["master_id"] == obj.version_id
+            assert kwargs["master_id"] == master_version_id
             assert kwargs["is_chapter_frame"] is True
             assert kwargs["context_type"] == "frame"
             assert kwargs["media_type"] == "image"
@@ -671,7 +672,7 @@ def test_extract_chapter_frames_task(app, db, bucket, video, users):
         # ---- Verify chapters.vtt creation ----
         mock_obj_create.assert_called_once()
         vtt_call_args = mock_obj_create.call_args
-        assert vtt_call_args.kwargs["bucket"] == obj.bucket
+        assert vtt_call_args.kwargs["bucket"] == bucket
         assert vtt_call_args.kwargs["key"] == "chapters.vtt"
 
         # Tags applied to chapters.vtt


### PR DESCRIPTION
Chapters timestamps should be unique, otherwise ffmpeg will fail and that will cause a loop for the task, it'll trigger itself.

- During sync we set `extract_chapters=False` so task can't trigger itself
- Parsing chapters method improved to return only unique timestamps
- During publish, instead of comparing chapters and chapter frames length, we'll compare the timestamps and if we're missing any it'll trigger the task